### PR TITLE
增强 养成计划 材料统计

### DIFF
--- a/src/Snap.Hutao/Snap.Hutao/Core/Setting/SettingKeys.cs
+++ b/src/Snap.Hutao/Snap.Hutao/Core/Setting/SettingKeys.cs
@@ -76,6 +76,7 @@ internal static class SettingKeys
     public const string ResinStatisticsSelectedDropDistribution = "Snap::Hutao::Cultivation::ResinStatistics::DropDistribution";
     public const string CultivationStatisticsMergeUpgradeMaterials      = "Snap::Hutao::Cultivation::Statistics::MergeUpgradeMaterials";
     public const string CultivationStatisticsTalentSynthCritTenPercent = "Snap::Hutao::Cultivation::Statistics::TalentSynthCritTenPercent";
+    public const string CultivationStatisticsWeeklyBossMaterialInterchange = "Snap::Hutao::Cultivation::Statistics::WeeklyBossMaterialInterchange";
 
     // GachaLog
     public const string IsEmptyHistoryWishVisible   = "Snap::Hutao::GachaLog::HistoryWish::EmptyVisible";

--- a/src/Snap.Hutao/Snap.Hutao/Core/Setting/SettingKeys.cs
+++ b/src/Snap.Hutao/Snap.Hutao/Core/Setting/SettingKeys.cs
@@ -74,6 +74,8 @@ internal static class SettingKeys
     public const string CultivationWeapon90LevelCurrent         = "Snap::Hutao::Cultivation::Weapon90::Level::Current";
     public const string CultivationWeapon90LevelTarget          = "Snap::Hutao::Cultivation::Weapon90::Level::Target";
     public const string ResinStatisticsSelectedDropDistribution = "Snap::Hutao::Cultivation::ResinStatistics::DropDistribution";
+    public const string CultivationStatisticsMergeUpgradeMaterials      = "Snap::Hutao::Cultivation::Statistics::MergeUpgradeMaterials";
+    public const string CultivationStatisticsTalentSynthCritTenPercent = "Snap::Hutao::Cultivation::Statistics::TalentSynthCritTenPercent";
 
     // GachaLog
     public const string IsEmptyHistoryWishVisible   = "Snap::Hutao::GachaLog::HistoryWish::EmptyVisible";

--- a/src/Snap.Hutao/Snap.Hutao/Core/Setting/SettingKeys.cs
+++ b/src/Snap.Hutao/Snap.Hutao/Core/Setting/SettingKeys.cs
@@ -77,6 +77,7 @@ internal static class SettingKeys
     public const string CultivationStatisticsMergeUpgradeMaterials      = "Snap::Hutao::Cultivation::Statistics::MergeUpgradeMaterials";
     public const string CultivationStatisticsTalentSynthCritTenPercent = "Snap::Hutao::Cultivation::Statistics::TalentSynthCritTenPercent";
     public const string CultivationStatisticsWeeklyBossMaterialInterchange = "Snap::Hutao::Cultivation::Statistics::WeeklyBossMaterialInterchange";
+    public const string CultivationRefreshInventoryByCalculatorToAllProjects = "Snap::Hutao::Cultivation::RefreshInventory::ByCalculator::ToAllProjects";
 
     // GachaLog
     public const string IsEmptyHistoryWishVisible   = "Snap::Hutao::GachaLog::HistoryWish::EmptyVisible";

--- a/src/Snap.Hutao/Snap.Hutao/Migrations/20260503131124_AddCultivateEntryRelatedEntryId.Designer.cs
+++ b/src/Snap.Hutao/Snap.Hutao/Migrations/20260503131124_AddCultivateEntryRelatedEntryId.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Snap.Hutao.Model.Entity.Database;
 
@@ -10,9 +11,11 @@ using Snap.Hutao.Model.Entity.Database;
 namespace Snap.Hutao.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260503131124_AddCultivateEntryRelatedEntryId")]
+    partial class AddCultivateEntryRelatedEntryId
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "10.0.0");

--- a/src/Snap.Hutao/Snap.Hutao/Migrations/20260503131124_AddCultivateEntryRelatedEntryId.cs
+++ b/src/Snap.Hutao/Snap.Hutao/Migrations/20260503131124_AddCultivateEntryRelatedEntryId.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Snap.Hutao.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddCultivateEntryRelatedEntryId : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<Guid>(
+                name: "RelatedEntryId",
+                table: "cultivate_entries",
+                type: "TEXT",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_cultivate_entries_RelatedEntryId",
+                table: "cultivate_entries",
+                column: "RelatedEntryId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_cultivate_entries_cultivate_entries_RelatedEntryId",
+                table: "cultivate_entries",
+                column: "RelatedEntryId",
+                principalTable: "cultivate_entries",
+                principalColumn: "InnerId",
+                onDelete: ReferentialAction.SetNull);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_cultivate_entries_cultivate_entries_RelatedEntryId",
+                table: "cultivate_entries");
+
+            migrationBuilder.DropIndex(
+                name: "IX_cultivate_entries_RelatedEntryId",
+                table: "cultivate_entries");
+
+            migrationBuilder.DropColumn(
+                name: "RelatedEntryId",
+                table: "cultivate_entries");
+        }
+    }
+}

--- a/src/Snap.Hutao/Snap.Hutao/Migrations/20260504014556_AddCultivateEntryAssociationOnly.cs
+++ b/src/Snap.Hutao/Snap.Hutao/Migrations/20260504014556_AddCultivateEntryAssociationOnly.cs
@@ -19,7 +19,8 @@ namespace Snap.Hutao.Migrations
                 table: "cultivate_entries",
                 column: "RelatedEntryId",
                 principalTable: "cultivate_entries",
-                principalColumn: "InnerId");
+                principalColumn: "InnerId",
+                onDelete: ReferentialAction.SetNull);
         }
 
         /// <inheritdoc />

--- a/src/Snap.Hutao/Snap.Hutao/Migrations/20260504014556_AddCultivateEntryAssociationOnly.cs
+++ b/src/Snap.Hutao/Snap.Hutao/Migrations/20260504014556_AddCultivateEntryAssociationOnly.cs
@@ -1,0 +1,41 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Snap.Hutao.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddCultivateEntryAssociationOnly : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_cultivate_entries_cultivate_entries_RelatedEntryId",
+                table: "cultivate_entries");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_cultivate_entries_cultivate_entries_RelatedEntryId",
+                table: "cultivate_entries",
+                column: "RelatedEntryId",
+                principalTable: "cultivate_entries",
+                principalColumn: "InnerId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_cultivate_entries_cultivate_entries_RelatedEntryId",
+                table: "cultivate_entries");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_cultivate_entries_cultivate_entries_RelatedEntryId",
+                table: "cultivate_entries",
+                column: "RelatedEntryId",
+                principalTable: "cultivate_entries",
+                principalColumn: "InnerId",
+                onDelete: ReferentialAction.SetNull);
+        }
+    }
+}

--- a/src/Snap.Hutao/Snap.Hutao/Migrations/20260504033049_AddCultivateProjectAvatarPropertyBatchPreferences.Designer.cs
+++ b/src/Snap.Hutao/Snap.Hutao/Migrations/20260504033049_AddCultivateProjectAvatarPropertyBatchPreferences.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Snap.Hutao.Model.Entity.Database;
 
@@ -10,9 +11,11 @@ using Snap.Hutao.Model.Entity.Database;
 namespace Snap.Hutao.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260504033049_AddCultivateProjectAvatarPropertyBatchPreferences")]
+    partial class AddCultivateProjectAvatarPropertyBatchPreferences
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "10.0.0");

--- a/src/Snap.Hutao/Snap.Hutao/Migrations/20260504033049_AddCultivateProjectAvatarPropertyBatchPreferences.cs
+++ b/src/Snap.Hutao/Snap.Hutao/Migrations/20260504033049_AddCultivateProjectAvatarPropertyBatchPreferences.cs
@@ -1,0 +1,51 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Snap.Hutao.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddCultivateProjectAvatarPropertyBatchPreferences : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_cultivate_entries_cultivate_entries_RelatedEntryId",
+                table: "cultivate_entries");
+
+            migrationBuilder.AddColumn<string>(
+                name: "AvatarPropertyBatchCultivatePreferencesJson",
+                table: "cultivate_projects",
+                type: "TEXT",
+                nullable: true);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_cultivate_entries_cultivate_entries_RelatedEntryId",
+                table: "cultivate_entries",
+                column: "RelatedEntryId",
+                principalTable: "cultivate_entries",
+                principalColumn: "InnerId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_cultivate_entries_cultivate_entries_RelatedEntryId",
+                table: "cultivate_entries");
+
+            migrationBuilder.DropColumn(
+                name: "AvatarPropertyBatchCultivatePreferencesJson",
+                table: "cultivate_projects");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_cultivate_entries_cultivate_entries_RelatedEntryId",
+                table: "cultivate_entries",
+                column: "RelatedEntryId",
+                principalTable: "cultivate_entries",
+                principalColumn: "InnerId",
+                onDelete: ReferentialAction.SetNull);
+        }
+    }
+}

--- a/src/Snap.Hutao/Snap.Hutao/Migrations/20260504055230_FixCultivateEntryRelatedEntryOnDeleteSetNull.cs
+++ b/src/Snap.Hutao/Snap.Hutao/Migrations/20260504055230_FixCultivateEntryRelatedEntryOnDeleteSetNull.cs
@@ -1,0 +1,41 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Snap.Hutao.Migrations
+{
+    /// <inheritdoc />
+    public partial class FixCultivateEntryRelatedEntryOnDeleteSetNull : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_cultivate_entries_cultivate_entries_RelatedEntryId",
+                table: "cultivate_entries");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_cultivate_entries_cultivate_entries_RelatedEntryId",
+                table: "cultivate_entries",
+                column: "RelatedEntryId",
+                principalTable: "cultivate_entries",
+                principalColumn: "InnerId",
+                onDelete: ReferentialAction.SetNull);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_cultivate_entries_cultivate_entries_RelatedEntryId",
+                table: "cultivate_entries");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_cultivate_entries_cultivate_entries_RelatedEntryId",
+                table: "cultivate_entries",
+                column: "RelatedEntryId",
+                principalTable: "cultivate_entries",
+                principalColumn: "InnerId");
+        }
+    }
+}

--- a/src/Snap.Hutao/Snap.Hutao/Migrations/AppDbContextModelSnapshot.cs
+++ b/src/Snap.Hutao/Snap.Hutao/Migrations/AppDbContextModelSnapshot.cs
@@ -595,7 +595,8 @@ namespace Snap.Hutao.Migrations
 
                     b.HasOne("Snap.Hutao.Model.Entity.CultivateEntry", "RelatedEntry")
                         .WithMany()
-                        .HasForeignKey("RelatedEntryId");
+                        .HasForeignKey("RelatedEntryId")
+                        .OnDelete(DeleteBehavior.SetNull);
 
                     b.Navigation("Project");
 

--- a/src/Snap.Hutao/Snap.Hutao/Model/Cultivation/CultivateProjectAvatarPropertyBatchPreferences.cs
+++ b/src/Snap.Hutao/Snap.Hutao/Model/Cultivation/CultivateProjectAvatarPropertyBatchPreferences.cs
@@ -1,0 +1,24 @@
+// Copyright (c) DGP Studio. All rights reserved.
+// Licensed under the MIT license.
+
+namespace Snap.Hutao.Model.Cultivation;
+
+/// <summary>
+/// 「我的角色」批量同步到当前养成计划时，在批量对话框中使用的目标等级、保存策略等；按 <see cref="Entity.CultivateProject"/> 持久化。
+/// </summary>
+internal sealed class CultivateProjectAvatarPropertyBatchPreferences
+{
+    public uint AvatarLevelTarget { get; set; }
+
+    public uint SkillATarget { get; set; }
+
+    public uint SkillETarget { get; set; }
+
+    public uint SkillQTarget { get; set; }
+
+    public uint WeaponLevelTarget { get; set; }
+
+    public int ConsumptionSaveStrategyIndex { get; set; }
+
+    public bool ClearAvatarAndWeaponEntriesBeforeSync { get; set; }
+}

--- a/src/Snap.Hutao/Snap.Hutao/Model/Cultivation/CultivateProjectAvatarPropertyBatchPreferences.cs
+++ b/src/Snap.Hutao/Snap.Hutao/Model/Cultivation/CultivateProjectAvatarPropertyBatchPreferences.cs
@@ -21,4 +21,14 @@ internal sealed class CultivateProjectAvatarPropertyBatchPreferences
     public int ConsumptionSaveStrategyIndex { get; set; }
 
     public bool ClearAvatarAndWeaponEntriesBeforeSync { get; set; }
+
+    /// <summary>
+    /// 执行批量前是否先通过养成计算器将游戏背包同步到当前计划（与养成计划「同步背包物品」一致）。
+    /// </summary>
+    public bool SyncInventoryItems { get; set; }
+
+    /// <summary>
+    /// 执行批量前是否先从米游社原神战绩同步「我的角色」数据（与我的角色「同步角色信息」一致）。
+    /// </summary>
+    public bool SyncCharacterInfo { get; set; }
 }

--- a/src/Snap.Hutao/Snap.Hutao/Model/Entity/Configuration/CultivateEntryConfiguration.cs
+++ b/src/Snap.Hutao/Snap.Hutao/Model/Entity/Configuration/CultivateEntryConfiguration.cs
@@ -1,0 +1,18 @@
+// Copyright (c) DGP Studio. All rights reserved.
+// Licensed under the MIT license.
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Snap.Hutao.Model.Entity.Configuration;
+
+internal sealed class CultivateEntryConfiguration : IEntityTypeConfiguration<CultivateEntry>
+{
+    public void Configure(EntityTypeBuilder<CultivateEntry> builder)
+    {
+        builder.HasOne(e => e.RelatedEntry)
+            .WithMany()
+            .HasForeignKey(e => e.RelatedEntryId)
+            .OnDelete(DeleteBehavior.SetNull);
+    }
+}

--- a/src/Snap.Hutao/Snap.Hutao/Model/Entity/CultivateEntry.cs
+++ b/src/Snap.Hutao/Snap.Hutao/Model/Entity/CultivateEntry.cs
@@ -26,6 +26,11 @@ internal sealed class CultivateEntry : IAppDbEntity
 
     public uint Id { get; set; }
 
+    public Guid? RelatedEntryId { get; set; }
+
+    [ForeignKey(nameof(RelatedEntryId))]
+    public CultivateEntry? RelatedEntry { get; set; }
+
     public static CultivateEntry From(Guid projectId, CultivateType type, uint id)
     {
         return new()

--- a/src/Snap.Hutao/Snap.Hutao/Model/Entity/CultivateProject.cs
+++ b/src/Snap.Hutao/Snap.Hutao/Model/Entity/CultivateProject.cs
@@ -22,6 +22,11 @@ internal sealed partial class CultivateProject : ISelectable,
 
     public TimeSpan ServerTimeZoneOffset { get; set; }
 
+    /// <summary>
+    /// <see cref="Model.Cultivation.CultivateProjectAvatarPropertyBatchPreferences"/> 的 JSON，按项目记忆批量同步养成选项。
+    /// </summary>
+    public string? AvatarPropertyBatchCultivatePreferencesJson { get; set; }
+
     public static CultivateProject From(string name, in TimeSpan serverTimeOffset)
     {
         return new()

--- a/src/Snap.Hutao/Snap.Hutao/Model/Entity/Database/AppDbContext.cs
+++ b/src/Snap.Hutao/Snap.Hutao/Model/Entity/Database/AppDbContext.cs
@@ -90,6 +90,7 @@ internal sealed partial class AppDbContext : DbContext
     {
         modelBuilder
             .ApplyConfiguration(new AvatarInfoConfiguration())
+            .ApplyConfiguration(new CultivateEntryConfiguration())
             .ApplyConfiguration(new DailyNoteEntryConfiguration())
             .ApplyConfiguration(new SpiralAbyssEntryConfiguration())
             .ApplyConfiguration(new RoleCombatEntryConfiguration())

--- a/src/Snap.Hutao/Snap.Hutao/Model/Metadata/Item/MaterialIds.cs
+++ b/src/Snap.Hutao/Snap.Hutao/Model/Metadata/Item/MaterialIds.cs
@@ -10,6 +10,18 @@ namespace Snap.Hutao.Model.Metadata.Item;
 
 internal static class MaterialIds
 {
+    /// <summary>
+    /// 材料统计右键「未完成条目」不追溯的材料（摩拉、经验书、精锻用魔矿）。
+    /// </summary>
+    public static bool IsExcludedFromStatisticsConsumerMenu(uint materialId)
+    {
+        return materialId is Mora
+            or WanderersAdvice
+            or AdventurersExperience
+            or HeroesWit
+            or MysticEnhancementOre;
+    }
+
     public const uint Mora = 202U;                       // 摩拉
     public const uint WanderersAdvice = 104001U;         // 流浪者的经验
     public const uint AdventurersExperience = 104002U;   // 冒险家的经验

--- a/src/Snap.Hutao/Snap.Hutao/Resource/Localization/SH.en.resx
+++ b/src/Snap.Hutao/Snap.Hutao/Resource/Localization/SH.en.resx
@@ -2420,6 +2420,12 @@ Space Available: {2}</value>
   <data name="ViewPageCultivationMaterialListIncompleteFirstLabel" xml:space="preserve">
     <value>Uncollected First</value>
   </data>
+  <data name="ViewPageCultivationMergeUpgradeMaterialsLabel" xml:space="preserve">
+    <value>Merge upgrade materials</value>
+  </data>
+  <data name="ViewPageCultivationTalentSynthCritTenPercentLabel" xml:space="preserve">
+    <value>Character talent (10%)</value>
+  </data>
   <data name="ViewPageCultivationMaterialListResinStatisticsLabel" xml:space="preserve">
     <value>Resin Estimation</value>
   </data>

--- a/src/Snap.Hutao/Snap.Hutao/Resource/Localization/SH.en.resx
+++ b/src/Snap.Hutao/Snap.Hutao/Resource/Localization/SH.en.resx
@@ -1880,6 +1880,9 @@ Space Available: {2}</value>
   <data name="ViewModelCultivationEntryViewPromoteOnlyHint" xml:space="preserve">
     <value>Ascending only</value>
   </data>
+  <data name="ViewModelCultivationEntryRelatedAvatar" xml:space="preserve">
+    <value>Linked character: {0}</value>
+  </data>
   <data name="ViewModelCultivationProjectAdded" xml:space="preserve">
     <value>Added successfully</value>
   </data>

--- a/src/Snap.Hutao/Snap.Hutao/Resource/Localization/SH.en.resx
+++ b/src/Snap.Hutao/Snap.Hutao/Resource/Localization/SH.en.resx
@@ -2435,6 +2435,15 @@ Space Available: {2}</value>
   <data name="ViewPageCultivationMaterialStatistics" xml:space="preserve">
     <value>Material Statistics</value>
   </data>
+  <data name="ViewPageCultivationStatisticsUnfinishedConsumers" xml:space="preserve">
+    <value>Unfinished: {0}</value>
+  </data>
+  <data name="ViewPageCultivationStatisticsUnfinishedConsumersEmptyList" xml:space="preserve">
+    <value>No unchecked entries</value>
+  </data>
+  <data name="ViewPageCultivationStatisticsConsumerMenuExcluded" xml:space="preserve">
+    <value>Mora, EXP books, and Mystic Enhancement Ore have no per-entry breakdown.</value>
+  </data>
   <data name="ViewPageCultivationNavigateAction" xml:space="preserve">
     <value>Go</value>
   </data>

--- a/src/Snap.Hutao/Snap.Hutao/Resource/Localization/SH.en.resx
+++ b/src/Snap.Hutao/Snap.Hutao/Resource/Localization/SH.en.resx
@@ -2435,9 +2435,6 @@ Space Available: {2}</value>
   <data name="ViewPageCultivationMaterialStatistics" xml:space="preserve">
     <value>Material Statistics</value>
   </data>
-  <data name="ViewPageCultivationStatisticsUnfinishedConsumers" xml:space="preserve">
-    <value>Unfinished: {0}</value>
-  </data>
   <data name="ViewPageCultivationStatisticsUnfinishedConsumersEmptyList" xml:space="preserve">
     <value>No unchecked entries</value>
   </data>

--- a/src/Snap.Hutao/Snap.Hutao/Resource/Localization/SH.en.resx
+++ b/src/Snap.Hutao/Snap.Hutao/Resource/Localization/SH.en.resx
@@ -1349,6 +1349,9 @@ Space Available: {2}</value>
   <data name="ViewDialogCultivateBatchWeaponLevelTarget" xml:space="preserve">
     <value>Weapon Target Level</value>
   </data>
+  <data name="ViewDialogCultivateBatchClearAvatarAndWeaponEntries" xml:space="preserve">
+    <value>Clear existing character and weapon entries before updating</value>
+  </data>
   <data name="ViewDialogCultivateProjectInputPlaceholder" xml:space="preserve">
     <value>Enter the plan name here</value>
   </data>

--- a/src/Snap.Hutao/Snap.Hutao/Resource/Localization/SH.en.resx
+++ b/src/Snap.Hutao/Snap.Hutao/Resource/Localization/SH.en.resx
@@ -2465,6 +2465,9 @@ Space Available: {2}</value>
   <data name="ViewPageCultivationRefreshInventoryByEmbeddedYae" xml:space="preserve">
     <value>Sync by Embedded Yae</value>
   </data>
+  <data name="ViewPageCultivationRefreshInventoryAllPlansShortLabel" xml:space="preserve">
+    <value>Inventory sync affects all plans</value>
+  </data>
   <data name="ViewPageCultivationRemoveEntry" xml:space="preserve">
     <value>Delete list</value>
   </data>

--- a/src/Snap.Hutao/Snap.Hutao/Resource/Localization/SH.en.resx
+++ b/src/Snap.Hutao/Snap.Hutao/Resource/Localization/SH.en.resx
@@ -2453,6 +2453,9 @@ Space Available: {2}</value>
   <data name="ViewPageCultivationNavigateAction" xml:space="preserve">
     <value>Go</value>
   </data>
+  <data name="ViewPageCultivationSyncAllAvatarsAndWeapons" xml:space="preserve">
+    <value>Sync All Characters and Weapons</value>
+  </data>
   <data name="ViewPageCultivationRefreshInventory" xml:space="preserve">
     <value>Sync Inventory Items</value>
   </data>

--- a/src/Snap.Hutao/Snap.Hutao/Resource/Localization/SH.en.resx
+++ b/src/Snap.Hutao/Snap.Hutao/Resource/Localization/SH.en.resx
@@ -2429,6 +2429,9 @@ Space Available: {2}</value>
   <data name="ViewPageCultivationTalentSynthCritTenPercentLabel" xml:space="preserve">
     <value>Character talent (10%)</value>
   </data>
+  <data name="ViewPageCultivationWeeklyBossMaterialInterchangeLabel" xml:space="preserve">
+    <value>Weekly boss material interchange</value>
+  </data>
   <data name="ViewPageCultivationMaterialListResinStatisticsLabel" xml:space="preserve">
     <value>Resin Estimation</value>
   </data>

--- a/src/Snap.Hutao/Snap.Hutao/Resource/Localization/SH.resx
+++ b/src/Snap.Hutao/Snap.Hutao/Resource/Localization/SH.resx
@@ -2504,6 +2504,9 @@
   <data name="ViewPageCultivationNavigateAction" xml:space="preserve">
     <value>前往</value>
   </data>
+  <data name="ViewPageCultivationSyncAllAvatarsAndWeapons" xml:space="preserve">
+    <value>同步所有角色与武器</value>
+  </data>
   <data name="ViewPageCultivationRefreshInventory" xml:space="preserve">
     <value>同步背包物品</value>
   </data>

--- a/src/Snap.Hutao/Snap.Hutao/Resource/Localization/SH.resx
+++ b/src/Snap.Hutao/Snap.Hutao/Resource/Localization/SH.resx
@@ -2486,6 +2486,15 @@
   <data name="ViewPageCultivationMaterialStatistics" xml:space="preserve">
     <value>材料统计</value>
   </data>
+  <data name="ViewPageCultivationStatisticsUnfinishedConsumers" xml:space="preserve">
+    <value>未完成：{0}</value>
+  </data>
+  <data name="ViewPageCultivationStatisticsUnfinishedConsumersEmptyList" xml:space="preserve">
+    <value>无未勾选条目</value>
+  </data>
+  <data name="ViewPageCultivationStatisticsConsumerMenuExcluded" xml:space="preserve">
+    <value>摩拉、经验书与魔矿不显示未完成条目。</value>
+  </data>
   <data name="ViewPageCultivationNavigateAction" xml:space="preserve">
     <value>前往</value>
   </data>

--- a/src/Snap.Hutao/Snap.Hutao/Resource/Localization/SH.resx
+++ b/src/Snap.Hutao/Snap.Hutao/Resource/Localization/SH.resx
@@ -2516,6 +2516,9 @@
   <data name="ViewPageCultivationRefreshInventoryByEmbeddedYae" xml:space="preserve">
     <value>通过 Embedded Yae 同步</value>
   </data>
+  <data name="ViewPageCultivationRefreshInventoryAllPlansShortLabel" xml:space="preserve">
+    <value>背包同步影响所有计划</value>
+  </data>
   <data name="ViewPageCultivationRemoveEntry" xml:space="preserve">
     <value>删除清单</value>
   </data>

--- a/src/Snap.Hutao/Snap.Hutao/Resource/Localization/SH.resx
+++ b/src/Snap.Hutao/Snap.Hutao/Resource/Localization/SH.resx
@@ -2486,9 +2486,6 @@
   <data name="ViewPageCultivationMaterialStatistics" xml:space="preserve">
     <value>材料统计</value>
   </data>
-  <data name="ViewPageCultivationStatisticsUnfinishedConsumers" xml:space="preserve">
-    <value>未完成：{0}</value>
-  </data>
   <data name="ViewPageCultivationStatisticsUnfinishedConsumersEmptyList" xml:space="preserve">
     <value>无未勾选条目</value>
   </data>

--- a/src/Snap.Hutao/Snap.Hutao/Resource/Localization/SH.resx
+++ b/src/Snap.Hutao/Snap.Hutao/Resource/Localization/SH.resx
@@ -2480,6 +2480,9 @@
   <data name="ViewPageCultivationTalentSynthCritTenPercentLabel" xml:space="preserve">
     <value>角色天赋（10%）</value>
   </data>
+  <data name="ViewPageCultivationWeeklyBossMaterialInterchangeLabel" xml:space="preserve">
+    <value>周本材料转化</value>
+  </data>
   <data name="ViewPageCultivationMaterialListResinStatisticsLabel" xml:space="preserve">
     <value>树脂预估</value>
   </data>

--- a/src/Snap.Hutao/Snap.Hutao/Resource/Localization/SH.resx
+++ b/src/Snap.Hutao/Snap.Hutao/Resource/Localization/SH.resx
@@ -1391,6 +1391,9 @@
   <data name="ViewDialogCultivateBatchWeaponLevelTarget" xml:space="preserve">
     <value>武器目标等级</value>
   </data>
+  <data name="ViewDialogCultivateBatchClearAvatarAndWeaponEntries" xml:space="preserve">
+    <value>更新计划前先清空已有角色与武器条目</value>
+  </data>
   <data name="ViewDialogCultivateProjectInputPlaceholder" xml:space="preserve">
     <value>在此处输入计划名称</value>
   </data>

--- a/src/Snap.Hutao/Snap.Hutao/Resource/Localization/SH.resx
+++ b/src/Snap.Hutao/Snap.Hutao/Resource/Localization/SH.resx
@@ -2475,7 +2475,7 @@
     <value>升级材料合并</value>
   </data>
   <data name="ViewPageCultivationTalentSynthCritTenPercentLabel" xml:space="preserve">
-    <value>人物天赋（10%）</value>
+    <value>角色天赋（10%）</value>
   </data>
   <data name="ViewPageCultivationMaterialListResinStatisticsLabel" xml:space="preserve">
     <value>树脂预估</value>

--- a/src/Snap.Hutao/Snap.Hutao/Resource/Localization/SH.resx
+++ b/src/Snap.Hutao/Snap.Hutao/Resource/Localization/SH.resx
@@ -2471,6 +2471,12 @@
   <data name="ViewPageCultivationMaterialListIncompleteFirstLabel" xml:space="preserve">
     <value>未集齐优先</value>
   </data>
+  <data name="ViewPageCultivationMergeUpgradeMaterialsLabel" xml:space="preserve">
+    <value>升级材料合并</value>
+  </data>
+  <data name="ViewPageCultivationTalentSynthCritTenPercentLabel" xml:space="preserve">
+    <value>人物天赋（10%）</value>
+  </data>
   <data name="ViewPageCultivationMaterialListResinStatisticsLabel" xml:space="preserve">
     <value>树脂预估</value>
   </data>

--- a/src/Snap.Hutao/Snap.Hutao/Resource/Localization/SH.resx
+++ b/src/Snap.Hutao/Snap.Hutao/Resource/Localization/SH.resx
@@ -1931,6 +1931,9 @@
   <data name="ViewModelCultivationEntryViewPromoteOnlyHint" xml:space="preserve">
     <value>仅突破</value>
   </data>
+  <data name="ViewModelCultivationEntryRelatedAvatar" xml:space="preserve">
+    <value>关联角色：{0}</value>
+  </data>
   <data name="ViewModelCultivationProjectAdded" xml:space="preserve">
     <value>添加成功</value>
   </data>

--- a/src/Snap.Hutao/Snap.Hutao/Resource/Localization/SH.zh-Hant.resx
+++ b/src/Snap.Hutao/Snap.Hutao/Resource/Localization/SH.zh-Hant.resx
@@ -2429,6 +2429,9 @@
   <data name="ViewPageCultivationNavigateAction" xml:space="preserve">
     <value>前往</value>
   </data>
+  <data name="ViewPageCultivationSyncAllAvatarsAndWeapons" xml:space="preserve">
+    <value>同步所有角色與武器</value>
+  </data>
   <data name="ViewPageCultivationRefreshInventory" xml:space="preserve">
     <value>同步背包物品</value>
   </data>

--- a/src/Snap.Hutao/Snap.Hutao/Service/Cultivation/AvatarPropertyBatchCultivateService.cs
+++ b/src/Snap.Hutao/Snap.Hutao/Service/Cultivation/AvatarPropertyBatchCultivateService.cs
@@ -108,8 +108,10 @@ internal sealed partial class AvatarPropertyBatchCultivateService : IAvatarPrope
 
             if (baseline.SyncInventoryItems)
             {
-                CultivateProject? project = await cultivationService.GetCurrentProjectAsync().ConfigureAwait(false);
-                if (project is not null)
+                Snap.Hutao.Core.Database.IAdvancedDbCollectionView<CultivateProject> projects = await cultivationService.GetProjectCollectionAsync().ConfigureAwait(false);
+                await cultivationService.EnsureCurrentProjectAsync(projects).ConfigureAwait(false);
+
+                if (projects.CurrentItem is { } project)
                 {
                     IMetadataService metadataService = serviceProvider.GetRequiredService<IMetadataService>();
                     ICultivationMetadataContext cultivationContext = await metadataService
@@ -153,6 +155,7 @@ internal sealed partial class AvatarPropertyBatchCultivateService : IAvatarPrope
 
                 if (!await SaveCultivationAsync(consumption, new CultivatePromotionDeltaOptions(delta, baseline.Strategy)).ConfigureAwait(false))
                 {
+                    result.StopReason = BatchCultivateStopReason.NoProject;
                     break;
                 }
 

--- a/src/Snap.Hutao/Snap.Hutao/Service/Cultivation/AvatarPropertyBatchCultivateService.cs
+++ b/src/Snap.Hutao/Snap.Hutao/Service/Cultivation/AvatarPropertyBatchCultivateService.cs
@@ -1,0 +1,179 @@
+// Copyright (c) DGP Studio. All rights reserved.
+// Licensed under the MIT license.
+
+using Microsoft.UI.Xaml.Controls;
+using Snap.Hutao.Factory.ContentDialog;
+using Snap.Hutao.Model.Calculable;
+using Snap.Hutao.Model.Cultivation;
+using Snap.Hutao.Model.Entity.Primitive;
+using Snap.Hutao.Service.AvatarInfo.Factory;
+using Snap.Hutao.Service.Cultivation.Consumption;
+using Snap.Hutao.Service.Cultivation.Offline;
+using Snap.Hutao.UI.Xaml.View.Dialog;
+using Snap.Hutao.ViewModel.AvatarProperty;
+using Snap.Hutao.Web.Hoyolab.Takumi.Event.Calculate;
+using System.Collections.Immutable;
+using CalculatorAvatarPromotionDelta = Snap.Hutao.Web.Hoyolab.Takumi.Event.Calculate.AvatarPromotionDelta;
+using CalculatorBatchConsumption = Snap.Hutao.Web.Hoyolab.Takumi.Event.Calculate.BatchConsumption;
+using CalculatorConsumption = Snap.Hutao.Web.Hoyolab.Takumi.Event.Calculate.Consumption;
+using CalculatorItemHelper = Snap.Hutao.Web.Hoyolab.Takumi.Event.Calculate.ItemHelper;
+
+namespace Snap.Hutao.Service.Cultivation;
+
+[Service(ServiceLifetime.Singleton, typeof(IAvatarPropertyBatchCultivateService))]
+internal sealed partial class AvatarPropertyBatchCultivateService : IAvatarPropertyBatchCultivateService
+{
+    private readonly IContentDialogFactory contentDialogFactory;
+    private readonly ICultivationService cultivationService;
+    private readonly IServiceProvider serviceProvider;
+
+    [GeneratedConstructor]
+    public partial AvatarPropertyBatchCultivateService(IServiceProvider serviceProvider);
+
+    public async ValueTask<BatchCultivateResult?> ExecuteAsync(SummaryFactoryMetadataContext metadataContext, ImmutableArray<AvatarView> targetAvatars, CancellationToken cancellationToken)
+    {
+        CultivateProjectAvatarPropertyBatchPreferences? batchPrefs = await cultivationService
+            .GetAvatarPropertyBatchCultivatePreferencesForCurrentProjectAsync()
+            .ConfigureAwait(false);
+
+        CultivatePromotionDeltaBatchDialog dialog = batchPrefs is null
+            ? await contentDialogFactory
+                .CreateInstanceAsync<CultivatePromotionDeltaBatchDialog>(serviceProvider)
+                .ConfigureAwait(false)
+            : await contentDialogFactory
+                .CreateInstanceAsync<CultivatePromotionDeltaBatchDialog>(serviceProvider, batchPrefs)
+                .ConfigureAwait(false);
+
+        if (await dialog.GetPromotionDeltaBaselineAsync().ConfigureAwait(false) is not (true, { } baseline))
+        {
+            return null;
+        }
+
+        await cultivationService
+            .SaveAvatarPropertyBatchCultivatePreferencesForCurrentProjectAsync(ToAvatarPropertyBatchPreferences(baseline))
+            .ConfigureAwait(false);
+
+        ArgumentNullException.ThrowIfNull(baseline.Delta.Weapon);
+
+        ContentDialog progressDialog = await contentDialogFactory
+            .CreateForIndeterminateProgressAsync(SH.ViewModelAvatarPropertyBatchCultivateProgressTitle)
+            .ConfigureAwait(false);
+
+        BatchCultivateResult result = default;
+        using (await contentDialogFactory.BlockAsync(progressDialog).ConfigureAwait(false))
+        {
+            if (baseline.ClearAvatarAndWeaponEntriesBeforeSync)
+            {
+                await cultivationService.RemoveAvatarAndWeaponEntriesForCurrentProjectAsync().ConfigureAwait(false);
+            }
+
+            ImmutableArray<CalculatorAvatarPromotionDelta>.Builder deltasBuilder = ImmutableArray.CreateBuilder<CalculatorAvatarPromotionDelta>();
+            foreach (AvatarView avatar in targetAvatars)
+            {
+                if (!baseline.Delta.TryGetNonErrorCopy(avatar, out CalculatorAvatarPromotionDelta? copy))
+                {
+                    ++result.SkippedCount;
+                    continue;
+                }
+
+                deltasBuilder.Add(copy);
+            }
+
+            ImmutableArray<CalculatorAvatarPromotionDelta> deltas = deltasBuilder.ToImmutable();
+
+            CalculatorBatchConsumption batchConsumption = OfflineCalculator.CalculateBatchConsumption(deltas, metadataContext);
+
+            foreach ((CalculatorConsumption consumption, CalculatorAvatarPromotionDelta delta) in batchConsumption.Items.Zip(deltas))
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                if (!await SaveCultivationAsync(consumption, new CultivatePromotionDeltaOptions(delta, baseline.Strategy)).ConfigureAwait(false))
+                {
+                    break;
+                }
+
+                ++result.SucceedCount;
+            }
+        }
+
+        return result;
+    }
+
+    private static CultivateProjectAvatarPropertyBatchPreferences ToAvatarPropertyBatchPreferences(CultivatePromotionDeltaOptions baseline)
+    {
+        CalculatorAvatarPromotionDelta d = baseline.Delta;
+        uint sa = 10;
+        uint se = 10;
+        uint sq = 10;
+        if (d.SkillList is [{ } a, { } e, { } q, ..])
+        {
+            sa = a.LevelTarget;
+            se = e.LevelTarget;
+            sq = q.LevelTarget;
+        }
+
+        return new CultivateProjectAvatarPropertyBatchPreferences
+        {
+            AvatarLevelTarget = d.AvatarLevelTarget,
+            SkillATarget = sa,
+            SkillETarget = se,
+            SkillQTarget = sq,
+            WeaponLevelTarget = d.Weapon?.LevelTarget ?? 90U,
+            ConsumptionSaveStrategyIndex = (int)baseline.Strategy,
+            ClearAvatarAndWeaponEntriesBeforeSync = baseline.ClearAvatarAndWeaponEntriesBeforeSync,
+        };
+    }
+
+    private async ValueTask<bool> SaveCultivationAsync(CalculatorConsumption consumption, CultivatePromotionDeltaOptions options)
+    {
+        LevelInformation levelInformation = LevelInformation.From(options.Delta);
+
+        InputConsumption avatarInput = new()
+        {
+            Type = CultivateType.AvatarAndSkill,
+            ItemId = options.Delta.AvatarId,
+            Items = CalculatorItemHelper.Merge(consumption.AvatarConsume, consumption.AvatarSkillConsume),
+            LevelInformation = levelInformation,
+            Strategy = options.Strategy,
+        };
+
+        ConsumptionSaveResult avatarSave = await cultivationService.SaveConsumptionAsync(avatarInput).ConfigureAwait(false);
+
+        if (avatarSave.Kind is ConsumptionSaveResultKind.NoProject)
+        {
+            return false;
+        }
+
+        ArgumentNullException.ThrowIfNull(options.Delta.Weapon);
+
+        Guid? relatedAvatarEntryId = avatarSave.CreatedEntryInnerId;
+        if (relatedAvatarEntryId is null && avatarSave.Kind is ConsumptionSaveResultKind.Skipped)
+        {
+            relatedAvatarEntryId = await cultivationService.TryGetAvatarCultivateEntryInnerIdAsync(options.Delta.AvatarId).ConfigureAwait(false);
+        }
+
+        if (relatedAvatarEntryId is null && avatarSave.Kind is ConsumptionSaveResultKind.NoItem)
+        {
+            relatedAvatarEntryId = await cultivationService.TryGetAvatarCultivateEntryInnerIdAsync(options.Delta.AvatarId).ConfigureAwait(false);
+        }
+
+        if (relatedAvatarEntryId is null && !consumption.WeaponConsume.IsEmpty)
+        {
+            relatedAvatarEntryId = await cultivationService.EnsureAvatarAssociationStubAsync(options.Delta.AvatarId, levelInformation).ConfigureAwait(false);
+        }
+
+        InputConsumption weaponInput = new()
+        {
+            Type = CultivateType.Weapon,
+            ItemId = options.Delta.Weapon.Id,
+            Items = consumption.WeaponConsume,
+            LevelInformation = levelInformation,
+            Strategy = options.Strategy,
+            RelatedEntryId = relatedAvatarEntryId,
+        };
+
+        ConsumptionSaveResult weaponSave = await cultivationService.SaveConsumptionAsync(weaponInput).ConfigureAwait(false);
+
+        return weaponSave.Kind is not ConsumptionSaveResultKind.NoProject;
+    }
+}

--- a/src/Snap.Hutao/Snap.Hutao/Service/Cultivation/AvatarPropertyBatchCultivateService.cs
+++ b/src/Snap.Hutao/Snap.Hutao/Service/Cultivation/AvatarPropertyBatchCultivateService.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 using Microsoft.UI.Xaml.Controls;
+using Snap.Hutao.Core.Setting;
 using Snap.Hutao.Factory.ContentDialog;
 using Snap.Hutao.Model.Calculable;
 using Snap.Hutao.Model.Cultivation;
@@ -117,7 +118,10 @@ internal sealed partial class AvatarPropertyBatchCultivateService : IAvatarPrope
 
                     IInventoryService inventoryService = serviceProvider.GetRequiredService<IInventoryService>();
                     await inventoryService
-                        .RefreshInventoryAsync(RefreshOptions.CreateForWebCalculator(project, cultivationContext))
+                        .RefreshInventoryAsync(RefreshOptions.CreateForWebCalculator(
+                            project,
+                            cultivationContext,
+                            LocalSetting.Get(SettingKeys.CultivationRefreshInventoryByCalculatorToAllProjects, false)))
                         .ConfigureAwait(false);
                 }
             }

--- a/src/Snap.Hutao/Snap.Hutao/Service/Cultivation/AvatarPropertyBatchCultivateService.cs
+++ b/src/Snap.Hutao/Snap.Hutao/Service/Cultivation/AvatarPropertyBatchCultivateService.cs
@@ -5,10 +5,17 @@ using Microsoft.UI.Xaml.Controls;
 using Snap.Hutao.Factory.ContentDialog;
 using Snap.Hutao.Model.Calculable;
 using Snap.Hutao.Model.Cultivation;
+using Snap.Hutao.Model.Entity;
 using Snap.Hutao.Model.Entity.Primitive;
+using Snap.Hutao.Model.Primitive;
+using Snap.Hutao.Service.AvatarInfo;
 using Snap.Hutao.Service.AvatarInfo.Factory;
 using Snap.Hutao.Service.Cultivation.Consumption;
 using Snap.Hutao.Service.Cultivation.Offline;
+using Snap.Hutao.Service.Inventory;
+using Snap.Hutao.Service.Metadata;
+using Snap.Hutao.Service.Metadata.ContextAbstraction;
+using Snap.Hutao.Service.User;
 using Snap.Hutao.UI.Xaml.View.Dialog;
 using Snap.Hutao.ViewModel.AvatarProperty;
 using Snap.Hutao.Web.Hoyolab.Takumi.Event.Calculate;
@@ -62,13 +69,66 @@ internal sealed partial class AvatarPropertyBatchCultivateService : IAvatarPrope
         BatchCultivateResult result = default;
         using (await contentDialogFactory.BlockAsync(progressDialog).ConfigureAwait(false))
         {
+            ImmutableArray<AvatarView> avatarsToProcess = targetAvatars;
+
+            if (baseline.SyncCharacterInfo)
+            {
+                IUserService userService = serviceProvider.GetRequiredService<IUserService>();
+                if (await userService.GetCurrentUserAndUidAsync().ConfigureAwait(false) is { } userAndUid)
+                {
+                    IServiceScopeFactory scopeFactory = serviceProvider.GetRequiredService<IServiceScopeFactory>();
+                    using (IServiceScope scope = scopeFactory.CreateScope())
+                    {
+                        IAvatarInfoService avatarInfoService = scope.ServiceProvider.GetRequiredService<IAvatarInfoService>();
+                        Summary? refreshed = await avatarInfoService
+                            .GetSummaryAsync(metadataContext, userAndUid, global::Snap.Hutao.Service.AvatarInfo.RefreshOptionKind.RequestFromHoyolabGameRecord, cancellationToken)
+                            .ConfigureAwait(false);
+
+                        if (refreshed?.Avatars.Source is { Count: > 0 } sourceAvatars)
+                        {
+                            HashSet<AvatarId> wanted = [.. targetAvatars.Select(static a => a.Id)];
+                            ImmutableArray<AvatarView>.Builder filtered = ImmutableArray.CreateBuilder<AvatarView>();
+                            foreach (AvatarView avatar in sourceAvatars)
+                            {
+                                if (wanted.Contains(avatar.Id))
+                                {
+                                    filtered.Add(avatar);
+                                }
+                            }
+
+                            if (filtered.Count > 0)
+                            {
+                                avatarsToProcess = filtered.ToImmutable();
+                            }
+                        }
+                    }
+                }
+            }
+
+            if (baseline.SyncInventoryItems)
+            {
+                CultivateProject? project = await cultivationService.GetCurrentProjectAsync().ConfigureAwait(false);
+                if (project is not null)
+                {
+                    IMetadataService metadataService = serviceProvider.GetRequiredService<IMetadataService>();
+                    ICultivationMetadataContext cultivationContext = await metadataService
+                        .GetContextAsync<CultivationMetadataContext>(cancellationToken)
+                        .ConfigureAwait(false);
+
+                    IInventoryService inventoryService = serviceProvider.GetRequiredService<IInventoryService>();
+                    await inventoryService
+                        .RefreshInventoryAsync(RefreshOptions.CreateForWebCalculator(project, cultivationContext))
+                        .ConfigureAwait(false);
+                }
+            }
+
             if (baseline.ClearAvatarAndWeaponEntriesBeforeSync)
             {
                 await cultivationService.RemoveAvatarAndWeaponEntriesForCurrentProjectAsync().ConfigureAwait(false);
             }
 
             ImmutableArray<CalculatorAvatarPromotionDelta>.Builder deltasBuilder = ImmutableArray.CreateBuilder<CalculatorAvatarPromotionDelta>();
-            foreach (AvatarView avatar in targetAvatars)
+            foreach (AvatarView avatar in avatarsToProcess)
             {
                 if (!baseline.Delta.TryGetNonErrorCopy(avatar, out CalculatorAvatarPromotionDelta? copy))
                 {
@@ -121,6 +181,8 @@ internal sealed partial class AvatarPropertyBatchCultivateService : IAvatarPrope
             WeaponLevelTarget = d.Weapon?.LevelTarget ?? 90U,
             ConsumptionSaveStrategyIndex = (int)baseline.Strategy,
             ClearAvatarAndWeaponEntriesBeforeSync = baseline.ClearAvatarAndWeaponEntriesBeforeSync,
+            SyncInventoryItems = baseline.SyncInventoryItems,
+            SyncCharacterInfo = baseline.SyncCharacterInfo,
         };
     }
 

--- a/src/Snap.Hutao/Snap.Hutao/Service/Cultivation/BatchCultivateResult.cs
+++ b/src/Snap.Hutao/Snap.Hutao/Service/Cultivation/BatchCultivateResult.cs
@@ -7,4 +7,11 @@ internal struct BatchCultivateResult
 {
     public int SucceedCount;
     public int SkippedCount;
+    public BatchCultivateStopReason StopReason;
+}
+
+internal enum BatchCultivateStopReason
+{
+    None = 0,
+    NoProject = 1,
 }

--- a/src/Snap.Hutao/Snap.Hutao/Service/Cultivation/BatchCultivateResult.cs
+++ b/src/Snap.Hutao/Snap.Hutao/Service/Cultivation/BatchCultivateResult.cs
@@ -1,7 +1,7 @@
 // Copyright (c) DGP Studio. All rights reserved.
 // Licensed under the MIT license.
 
-namespace Snap.Hutao.ViewModel.AvatarProperty;
+namespace Snap.Hutao.Service.Cultivation;
 
 internal struct BatchCultivateResult
 {

--- a/src/Snap.Hutao/Snap.Hutao/Service/Cultivation/Consumption/ConsumptionSaveResult.cs
+++ b/src/Snap.Hutao/Snap.Hutao/Service/Cultivation/Consumption/ConsumptionSaveResult.cs
@@ -1,0 +1,8 @@
+// Copyright (c) DGP Studio. All rights reserved.
+// Licensed under the MIT license.
+
+namespace Snap.Hutao.Service.Cultivation.Consumption;
+
+internal readonly record struct ConsumptionSaveResult(
+    ConsumptionSaveResultKind Kind,
+    Guid? CreatedEntryInnerId = null);

--- a/src/Snap.Hutao/Snap.Hutao/Service/Cultivation/CultivationMetadataContext.cs
+++ b/src/Snap.Hutao/Snap.Hutao/Service/Cultivation/CultivationMetadataContext.cs
@@ -23,6 +23,9 @@ internal class CultivationMetadataContext : ICultivationMetadataContext
 
     public ImmutableDictionary<MaterialId, Combine> ResultMaterialIdCombineMap { get; set; } = default!;
 
+    public ImmutableArray<ImmutableArray<MaterialId>> WeeklyBossMaterialInterchangeGroups { get; set; }
+        = ImmutableArray<ImmutableArray<MaterialId>>.Empty;
+
     public Item GetAvatarItem(AvatarId avatarId)
     {
         return this.GetAvatar(avatarId).GetOrCreateItem();

--- a/src/Snap.Hutao/Snap.Hutao/Service/Cultivation/CultivationRepository.cs
+++ b/src/Snap.Hutao/Snap.Hutao/Service/Cultivation/CultivationRepository.cs
@@ -58,10 +58,18 @@ internal sealed partial class CultivationRepository : ICultivationRepository
         using (IServiceScope scope = ServiceProvider.CreateScope())
         {
             AppDbContext db = scope.GetAppDbContext();
+            // EF Core 不会为 SQLite 的隐式 rowid 自动建模；这里用原生 SQL 取最新插入的一条。
             return db.Set<CultivateEntry>()
+                .FromSqlInterpolated($"""
+                SELECT *
+                FROM cultivate_entries
+                WHERE ProjectId = {projectId}
+                  AND Id = {avatarId}
+                  AND Type = {(int)CultivateType.AvatarAndSkill}
+                ORDER BY rowid DESC
+                LIMIT 1
+                """)
                 .AsNoTracking()
-                .Where(e => e.ProjectId == projectId && e.Id == avatarId && e.Type == CultivateType.AvatarAndSkill)
-                .OrderByDescending(e => EF.Property<long>(e, "rowid"))
                 .Select(e => (Guid?)e.InnerId)
                 .FirstOrDefault();
         }

--- a/src/Snap.Hutao/Snap.Hutao/Service/Cultivation/CultivationRepository.cs
+++ b/src/Snap.Hutao/Snap.Hutao/Service/Cultivation/CultivationRepository.cs
@@ -102,6 +102,11 @@ internal sealed partial class CultivationRepository : ICultivationRepository
         return this.ObservableCollection<CultivateProject>();
     }
 
+    public ImmutableArray<Guid> GetCultivateProjectInnerIds()
+    {
+        return this.ImmutableArray<CultivateProject, Guid>(query => query.Select(p => p.InnerId));
+    }
+
     public void RemoveLevelInformationByEntryId(Guid entryId)
     {
         this.Delete<CultivateEntryLevelInformation>(l => l.EntryId == entryId);

--- a/src/Snap.Hutao/Snap.Hutao/Service/Cultivation/CultivationRepository.cs
+++ b/src/Snap.Hutao/Snap.Hutao/Service/Cultivation/CultivationRepository.cs
@@ -54,22 +54,17 @@ internal sealed partial class CultivationRepository : ICultivationRepository
 
     public Guid? TryGetAvatarCultivateEntryInnerId(Guid projectId, uint avatarId)
     {
-        ImmutableArray<CultivateEntry> entries = GetCultivateEntryImmutableArrayByProjectIdAndItemId(projectId, avatarId);
-        Guid? last = null;
-        foreach (ref readonly CultivateEntry entry in entries.AsSpan())
+        // NOTE: InnerId(Guid) 的大小不代表插入顺序；这里使用 SQLite 的 rowid 选择最新插入的一条。
+        using (IServiceScope scope = ServiceProvider.CreateScope())
         {
-            if (entry.Type != CultivateType.AvatarAndSkill)
-            {
-                continue;
-            }
-
-            if (last is null || entry.InnerId.CompareTo(last.Value) > 0)
-            {
-                last = entry.InnerId;
-            }
+            AppDbContext db = scope.GetAppDbContext();
+            return db.Set<CultivateEntry>()
+                .AsNoTracking()
+                .Where(e => e.ProjectId == projectId && e.Id == avatarId && e.Type == CultivateType.AvatarAndSkill)
+                .OrderByDescending(e => EF.Property<long>(e, "rowid"))
+                .Select(e => (Guid?)e.InnerId)
+                .FirstOrDefault();
         }
-
-        return last;
     }
 
     public void AddCultivateEntry(CultivateEntry entry)

--- a/src/Snap.Hutao/Snap.Hutao/Service/Cultivation/CultivationRepository.cs
+++ b/src/Snap.Hutao/Snap.Hutao/Service/Cultivation/CultivationRepository.cs
@@ -2,10 +2,14 @@
 // Licensed under the MIT license.
 
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Snap.Hutao.Core.Database;
 using Snap.Hutao.Model.Entity;
+using Snap.Hutao.Model.Entity.Database;
 using Snap.Hutao.Service.Abstraction;
 using System.Collections.Immutable;
 using System.Collections.ObjectModel;
+using System.Linq;
 
 namespace Snap.Hutao.Service.Cultivation;
 
@@ -95,5 +99,24 @@ internal sealed partial class CultivationRepository : ICultivationRepository
     public Guid GetCultivateProjectIdByEntryId(Guid entryId)
     {
         return this.Single<CultivateEntry, Guid>(query => query.Where(entry => entry.InnerId == entryId).Select(entry => entry.InnerId));
+    }
+
+    public ImmutableArray<(CultivateEntry Entry, CultivateItem Item)> GetCultivateEntryItemPairsByProjectId(Guid projectId)
+    {
+        using (IServiceScope scope = ServiceProvider.CreateScope())
+        {
+            AppDbContext db = scope.GetAppDbContext();
+            IQueryable<CultivateEntry> entries = db.Set<CultivateEntry>().AsNoTracking().Where(e => e.ProjectId == projectId);
+            return [.. db.Set<CultivateItem>().AsNoTracking()
+                .Join(
+                    entries,
+                    item => item.EntryId,
+                    entry => entry.InnerId,
+                    (item, entry) => new { Entry = entry, Item = item })
+                .OrderBy(t => t.Entry.InnerId)
+                .ThenBy(t => t.Item.ItemId)
+                .ToList()
+                .Select(t => (t.Entry, t.Item))];
+        }
     }
 }

--- a/src/Snap.Hutao/Snap.Hutao/Service/Cultivation/CultivationRepository.cs
+++ b/src/Snap.Hutao/Snap.Hutao/Service/Cultivation/CultivationRepository.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Snap.Hutao.Core.Database;
 using Snap.Hutao.Model.Entity;
 using Snap.Hutao.Model.Entity.Database;
+using Snap.Hutao.Model.Entity.Primitive;
 using Snap.Hutao.Service.Abstraction;
 using System.Collections.Immutable;
 using System.Collections.ObjectModel;
@@ -49,6 +50,26 @@ internal sealed partial class CultivationRepository : ICultivationRepository
     public ImmutableArray<CultivateEntry> GetCultivateEntryImmutableArrayByProjectIdAndItemId(Guid projectId, uint itemId)
     {
         return this.ImmutableArray<CultivateEntry>(e => e.ProjectId == projectId && e.Id == itemId);
+    }
+
+    public Guid? TryGetAvatarCultivateEntryInnerId(Guid projectId, uint avatarId)
+    {
+        ImmutableArray<CultivateEntry> entries = GetCultivateEntryImmutableArrayByProjectIdAndItemId(projectId, avatarId);
+        Guid? last = null;
+        foreach (ref readonly CultivateEntry entry in entries.AsSpan())
+        {
+            if (entry.Type != CultivateType.AvatarAndSkill)
+            {
+                continue;
+            }
+
+            if (last is null || entry.InnerId.CompareTo(last.Value) > 0)
+            {
+                last = entry.InnerId;
+            }
+        }
+
+        return last;
     }
 
     public void AddCultivateEntry(CultivateEntry entry)

--- a/src/Snap.Hutao/Snap.Hutao/Service/Cultivation/CultivationResinStatisticsService.cs
+++ b/src/Snap.Hutao/Snap.Hutao/Service/Cultivation/CultivationResinStatisticsService.cs
@@ -124,6 +124,6 @@ internal sealed partial class CultivationResinStatisticsService : ICultivationRe
 
     private static double GetStatisticsCultivateItemTimes(StatisticsCultivateItem item)
     {
-        return item.Count - (long)item.Current;
+        return item.Count - (long)item.DisplayCurrent;
     }
 }

--- a/src/Snap.Hutao/Snap.Hutao/Service/Cultivation/CultivationService.cs
+++ b/src/Snap.Hutao/Snap.Hutao/Service/Cultivation/CultivationService.cs
@@ -2,18 +2,23 @@
 // Licensed under the MIT license.
 
 using Snap.Hutao.Core.Database;
+using Snap.Hutao.Model;
 using Snap.Hutao.Model.Entity;
 using Snap.Hutao.Model.Entity.Primitive;
 using Snap.Hutao.Model.Intrinsic;
 using Snap.Hutao.Model.Metadata;
+using Snap.Hutao.Model.Metadata.Item;
 using Snap.Hutao.Model.Primitive;
 using Snap.Hutao.Service.Cultivation.Consumption;
 using Snap.Hutao.Service.Inventory;
 using Snap.Hutao.Service.Metadata.ContextAbstraction;
 using Snap.Hutao.ViewModel.Cultivation;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Globalization;
 using System.Collections.Immutable;
 using System.Collections.ObjectModel;
+using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using ModelItem = Snap.Hutao.Model.Item;
@@ -130,6 +135,7 @@ internal sealed partial class CultivationService : ICultivationService
             }
 
             CultivationStatisticsSurplusMerge.Apply(resultItems, context, mergeOptions);
+            ApplyStatisticsConsumerMenuText(resultItems, projectId, context, cultivationRepository);
 
             return new(resultItems);
         }
@@ -304,5 +310,64 @@ internal sealed partial class CultivationService : ICultivationService
                 RecursiveAddMaterialIngredientsByMaterialId(cultivateProject, context, resultItems, ingredient.Id);
             }
         }
+    }
+
+    private static void ApplyStatisticsConsumerMenuText(
+        Dictionary<uint, StatisticsCultivateItem> resultItems,
+        Guid projectId,
+        ICultivationMetadataContext context,
+        ICultivationRepository cultivationRepository)
+    {
+        ImmutableArray<(CultivateEntry Entry, CultivateItem Item)> pairs = cultivationRepository.GetCultivateEntryItemPairsByProjectId(projectId);
+        Dictionary<uint, List<string>> unfinishedSegmentsByMaterial = [];
+
+        foreach ((CultivateEntry entry, CultivateItem item) in pairs.AsSpan())
+        {
+            if (item.IsFinished)
+            {
+                continue;
+            }
+
+            string name = FormatStatisticsConsumerEntryName(entry, context);
+            string segment = $"{name}×{item.Count}";
+            ref List<string>? list = ref CollectionsMarshal.GetValueRefOrAddDefault(unfinishedSegmentsByMaterial, item.ItemId, out _);
+            list ??= [];
+            list.Add(segment);
+        }
+
+        foreach ((uint materialId, StatisticsCultivateItem stat) in resultItems)
+        {
+            if (MaterialIds.IsExcludedFromStatisticsConsumerMenu(materialId))
+            {
+                stat.StatisticsConsumerMenuText = SH.ViewPageCultivationStatisticsConsumerMenuExcluded;
+                continue;
+            }
+
+            if (unfinishedSegmentsByMaterial.TryGetValue(materialId, out List<string>? segments))
+            {
+                segments.Sort(StringComparer.Ordinal);
+                stat.StatisticsConsumerMenuText = string.Format(
+                    CultureInfo.CurrentCulture,
+                    SH.ViewPageCultivationStatisticsUnfinishedConsumers,
+                    string.Join('，', segments));
+            }
+            else
+            {
+                stat.StatisticsConsumerMenuText = string.Format(
+                    CultureInfo.CurrentCulture,
+                    SH.ViewPageCultivationStatisticsUnfinishedConsumers,
+                    SH.ViewPageCultivationStatisticsUnfinishedConsumersEmptyList);
+            }
+        }
+    }
+
+    private static string FormatStatisticsConsumerEntryName(CultivateEntry entry, ICultivationMetadataContext context)
+    {
+        return entry.Type switch
+        {
+            CultivateType.AvatarAndSkill => context.GetAvatarItem(entry.Id).Name,
+            CultivateType.Weapon => context.GetWeaponItem(entry.Id).Name,
+            _ => Material.Default.Name,
+        };
     }
 }

--- a/src/Snap.Hutao/Snap.Hutao/Service/Cultivation/CultivationService.cs
+++ b/src/Snap.Hutao/Snap.Hutao/Service/Cultivation/CultivationService.cs
@@ -92,12 +92,12 @@ internal sealed partial class CultivationService : ICultivationService
         }
     }
 
-    public async ValueTask<StatisticsCultivateItemCollection> GetStatisticsCultivateItemCollectionAsync(CultivateProject cultivateProject, ICultivationMetadataContext context, CancellationToken token)
+    public async ValueTask<StatisticsCultivateItemCollection> GetStatisticsCultivateItemCollectionAsync(CultivateProject cultivateProject, ICultivationMetadataContext context, CultivationStatisticsMergeOptions mergeOptions, CancellationToken token)
     {
         await taskContext.SwitchToBackgroundAsync();
-        return SynchronizedGetStatisticsCultivateItemCollection(cultivateProject, context);
+        return SynchronizedGetStatisticsCultivateItemCollection(cultivateProject, context, mergeOptions);
 
-        StatisticsCultivateItemCollection SynchronizedGetStatisticsCultivateItemCollection(CultivateProject cultivateProject, ICultivationMetadataContext context)
+        StatisticsCultivateItemCollection SynchronizedGetStatisticsCultivateItemCollection(CultivateProject cultivateProject, ICultivationMetadataContext context, CultivationStatisticsMergeOptions mergeOptions)
         {
             Dictionary</* ItemId */ uint, StatisticsCultivateItem> resultItems = [];
             Guid projectId = cultivateProject.InnerId;
@@ -128,6 +128,8 @@ internal sealed partial class CultivationService : ICultivationService
                     existedItem.Current = inventoryItem.Count;
                 }
             }
+
+            CultivationStatisticsSurplusMerge.Apply(resultItems, context, mergeOptions);
 
             return new(resultItems);
         }

--- a/src/Snap.Hutao/Snap.Hutao/Service/Cultivation/CultivationService.cs
+++ b/src/Snap.Hutao/Snap.Hutao/Service/Cultivation/CultivationService.cs
@@ -152,6 +152,10 @@ internal sealed partial class CultivationService : ICultivationService
             }
 
             CultivationStatisticsSurplusMerge.Apply(resultItems, context, mergeOptions);
+            CultivationStatisticsWeeklyBossInterchange.Apply(
+                resultItems,
+                context.WeeklyBossMaterialInterchangeGroups,
+                mergeOptions.WeeklyBossMaterialInterchange);
             ApplyStatisticsConsumerMenuLines(resultItems, projectId, context, cultivationRepository, token);
 
             return new(resultItems);

--- a/src/Snap.Hutao/Snap.Hutao/Service/Cultivation/CultivationService.cs
+++ b/src/Snap.Hutao/Snap.Hutao/Service/Cultivation/CultivationService.cs
@@ -394,7 +394,8 @@ internal sealed partial class CultivationService : ICultivationService
         ICultivationMetadataContext context,
         Dictionary<Guid, CultivateEntry> entryByInnerId)
     {
-        string countSuffix = $"×{item.Count}";
+        // 展示用量：全角括号比「×数量」更利落，且与中文混排更协调。
+        string countSuffix = $"\uFF08{item.Count}\uFF09";
 
         switch (entry.Type)
         {

--- a/src/Snap.Hutao/Snap.Hutao/Service/Cultivation/CultivationService.cs
+++ b/src/Snap.Hutao/Snap.Hutao/Service/Cultivation/CultivationService.cs
@@ -178,6 +178,48 @@ internal sealed partial class CultivationService : ICultivationService
         cultivationRepository.RemoveCultivateEntryById(entryId);
     }
 
+    public async ValueTask RemoveAvatarAndWeaponEntriesForCurrentProjectAsync()
+    {
+        IAdvancedDbCollectionView<CultivateProject> projects = await GetProjectCollectionAsync().ConfigureAwait(false);
+        if (!await EnsureCurrentProjectAsync(projects).ConfigureAwait(false))
+        {
+            return;
+        }
+
+        ArgumentNullException.ThrowIfNull(projects.CurrentItem);
+        Guid projectId = projects.CurrentItem.InnerId;
+
+        await taskContext.SwitchToBackgroundAsync();
+
+        ImmutableArray<CultivateEntry> entries = cultivationRepository.GetCultivateEntryImmutableArrayByProjectId(projectId);
+        List<Guid> weaponEntryIds = new(entries.Length);
+        List<Guid> avatarEntryIds = new(entries.Length);
+        foreach (ref readonly CultivateEntry entry in entries.AsSpan())
+        {
+            switch (entry.Type)
+            {
+                case CultivateType.Weapon:
+                    weaponEntryIds.Add(entry.InnerId);
+                    break;
+                case CultivateType.AvatarAndSkill:
+                    avatarEntryIds.Add(entry.InnerId);
+                    break;
+            }
+        }
+
+        foreach (Guid id in weaponEntryIds)
+        {
+            cultivationRepository.RemoveCultivateEntryById(id);
+        }
+
+        foreach (Guid id in avatarEntryIds)
+        {
+            cultivationRepository.RemoveCultivateEntryById(id);
+        }
+
+        entryCollectionCache.TryRemove(projectId, out _);
+    }
+
     public void SaveCultivateItem(CultivateItemView item)
     {
         cultivationRepository.UpdateCultivateItem(item.Entity);

--- a/src/Snap.Hutao/Snap.Hutao/Service/Cultivation/CultivationService.cs
+++ b/src/Snap.Hutao/Snap.Hutao/Service/Cultivation/CultivationService.cs
@@ -129,6 +129,7 @@ internal sealed partial class CultivationService : ICultivationService
             token.ThrowIfCancellationRequested();
             Dictionary</* ItemId */ uint, StatisticsCultivateItem> resultItems = [];
             Guid projectId = cultivateProject.InnerId;
+            Dictionary<uint, uint> inventoryCounts = [];
 
             foreach (ref readonly CultivateEntry entry in cultivationRepository.GetCultivateEntryImmutableArrayByProjectId(projectId).AsSpan())
             {
@@ -153,12 +154,20 @@ internal sealed partial class CultivationService : ICultivationService
             foreach (ref readonly InventoryItem inventoryItem in inventoryRepository.GetInventoryItemImmutableArrayByProjectId(projectId).AsSpan())
             {
                 token.ThrowIfCancellationRequested();
+                inventoryCounts[inventoryItem.ItemId] = inventoryItem.Count;
                 ref StatisticsCultivateItem existedItem = ref CollectionsMarshal.GetValueRefOrNullRef(resultItems, inventoryItem.ItemId);
                 if (!Unsafe.IsNullRef(in existedItem))
                 {
                     existedItem.Current = inventoryItem.Count;
                 }
             }
+
+            AddWeeklyBossGroupInventoryDonors(
+                resultItems,
+                inventoryCounts,
+                context,
+                cultivateProject.ServerTimeZoneOffset,
+                mergeOptions.WeeklyBossMaterialInterchange);
 
             CultivationStatisticsSurplusMerge.Apply(resultItems, context, mergeOptions);
             CultivationStatisticsWeeklyBossInterchange.Apply(
@@ -168,6 +177,55 @@ internal sealed partial class CultivationService : ICultivationService
             ApplyStatisticsConsumerMenuLines(resultItems, projectId, context, cultivationRepository, token);
 
             return new(resultItems);
+        }
+    }
+
+    private static void AddWeeklyBossGroupInventoryDonors(
+        Dictionary<uint, StatisticsCultivateItem> items,
+        Dictionary<uint, uint> inventoryCounts,
+        ICultivationMetadataContext context,
+        TimeSpan offset,
+        bool enabled)
+    {
+        if (!enabled || context.WeeklyBossMaterialInterchangeGroups.IsDefaultOrEmpty)
+        {
+            return;
+        }
+
+        foreach (ImmutableArray<MaterialId> group in context.WeeklyBossMaterialInterchangeGroups)
+        {
+            bool anyPlannedInGroup = false;
+            foreach (MaterialId mid in group)
+            {
+                if (items.ContainsKey(mid))
+                {
+                    anyPlannedInGroup = true;
+                    break;
+                }
+            }
+
+            if (!anyPlannedInGroup)
+            {
+                continue;
+            }
+
+            foreach (MaterialId mid in group)
+            {
+                uint id = mid;
+                if (items.ContainsKey(id))
+                {
+                    continue;
+                }
+
+                if (!inventoryCounts.TryGetValue(id, out uint inv) || inv is 0U)
+                {
+                    continue;
+                }
+
+                StatisticsCultivateItem donor = StatisticsCultivateItem.Create(context.GetMaterial(id), offset);
+                donor.Current = inv;
+                items[id] = donor;
+            }
         }
     }
 

--- a/src/Snap.Hutao/Snap.Hutao/Service/Cultivation/CultivationService.cs
+++ b/src/Snap.Hutao/Snap.Hutao/Service/Cultivation/CultivationService.cs
@@ -352,7 +352,7 @@ internal sealed partial class CultivationService : ICultivationService
             entryByInnerId[e.InnerId] = e;
         }
 
-        Dictionary<uint, List<string>> unfinishedSegmentsByMaterial = [];
+        Dictionary<uint, List<(string SortKey, StatisticsConsumerMenuLine Line)>> unfinishedRowsByMaterial = [];
 
         foreach ((CultivateEntry entry, CultivateItem item) in pairs.AsSpan())
         {
@@ -361,30 +361,72 @@ internal sealed partial class CultivationService : ICultivationService
                 continue;
             }
 
-            string name = FormatStatisticsConsumerEntryName(entry, context, entryByInnerId);
-            string segment = $"{name}×{item.Count}";
-            ref List<string>? list = ref CollectionsMarshal.GetValueRefOrAddDefault(unfinishedSegmentsByMaterial, item.ItemId, out _);
+            string sortKey = $"{FormatStatisticsConsumerEntryName(entry, context, entryByInnerId)}×{item.Count}";
+            StatisticsConsumerMenuLine line = CreateStatisticsConsumerMenuLine(entry, item, context, entryByInnerId);
+            ref List<(string SortKey, StatisticsConsumerMenuLine Line)>? list = ref CollectionsMarshal.GetValueRefOrAddDefault(unfinishedRowsByMaterial, item.ItemId, out _);
             list ??= [];
-            list.Add(segment);
+            list.Add((sortKey, line));
         }
 
         foreach ((uint materialId, StatisticsCultivateItem stat) in resultItems)
         {
             if (MaterialIds.IsExcludedFromStatisticsConsumerMenu(materialId))
             {
-                stat.StatisticsConsumerMenuLines = ImmutableArray.Create(SH.ViewPageCultivationStatisticsConsumerMenuExcluded);
+                stat.StatisticsConsumerMenuLines = ImmutableArray.Create(StatisticsConsumerMenuLine.Plain(SH.ViewPageCultivationStatisticsConsumerMenuExcluded));
                 continue;
             }
 
-            if (unfinishedSegmentsByMaterial.TryGetValue(materialId, out List<string>? segments))
+            if (unfinishedRowsByMaterial.TryGetValue(materialId, out List<(string SortKey, StatisticsConsumerMenuLine Line)>? rows))
             {
-                segments.Sort(StringComparer.Ordinal);
-                stat.StatisticsConsumerMenuLines = ImmutableArray.CreateRange(segments);
+                rows.Sort(static (a, b) => StringComparer.Ordinal.Compare(a.SortKey, b.SortKey));
+                stat.StatisticsConsumerMenuLines = ImmutableArray.CreateRange(rows.ConvertAll(static r => r.Line));
             }
             else
             {
-                stat.StatisticsConsumerMenuLines = ImmutableArray.Create(SH.ViewPageCultivationStatisticsUnfinishedConsumersEmptyList);
+                stat.StatisticsConsumerMenuLines = ImmutableArray.Create(StatisticsConsumerMenuLine.Plain(SH.ViewPageCultivationStatisticsUnfinishedConsumersEmptyList));
             }
+        }
+    }
+
+    private static StatisticsConsumerMenuLine CreateStatisticsConsumerMenuLine(
+        CultivateEntry entry,
+        CultivateItem item,
+        ICultivationMetadataContext context,
+        Dictionary<Guid, CultivateEntry> entryByInnerId)
+    {
+        string countSuffix = $"×{item.Count}";
+
+        switch (entry.Type)
+        {
+            case CultivateType.AvatarAndSkill:
+            {
+                ModelItem avatarItem = context.GetAvatarItem(entry.Id);
+                return StatisticsConsumerMenuLine.SingleIcon(avatarItem.Icon, avatarItem.Quality, avatarItem.Name, countSuffix);
+            }
+
+            case CultivateType.Weapon:
+            {
+                ModelItem weaponItem = context.GetWeaponItem(entry.Id);
+                if (entry.RelatedEntryId is Guid relatedId
+                    && entryByInnerId.TryGetValue(relatedId, out CultivateEntry? related)
+                    && related.Type is CultivateType.AvatarAndSkill)
+                {
+                    ModelItem avatarItem = context.GetAvatarItem(related.Id);
+                    return StatisticsConsumerMenuLine.AvatarAndWeapon(
+                        avatarItem.Icon,
+                        avatarItem.Quality,
+                        avatarItem.Name,
+                        weaponItem.Icon,
+                        weaponItem.Quality,
+                        weaponItem.Name,
+                        countSuffix);
+                }
+
+                return StatisticsConsumerMenuLine.SingleIcon(weaponItem.Icon, weaponItem.Quality, weaponItem.Name, countSuffix);
+            }
+
+            default:
+                return StatisticsConsumerMenuLine.Plain($"{Material.Default.Name}{countSuffix}");
         }
     }
 

--- a/src/Snap.Hutao/Snap.Hutao/Service/Cultivation/CultivationService.cs
+++ b/src/Snap.Hutao/Snap.Hutao/Service/Cultivation/CultivationService.cs
@@ -77,6 +77,11 @@ internal sealed partial class CultivationService : ICultivationService
             foreach (ref readonly CultivateEntry entry in entries.AsSpan())
             {
                 ImmutableArray<CultivateItem> items = cultivationRepository.GetCultivateItemImmutableArrayByEntryId(entry.InnerId);
+                if (IsHiddenAssociationOnlyAvatarEntry(entry, items.Length))
+                {
+                    continue;
+                }
+
                 ImmutableArray<CultivateItemView>.Builder entryItems = ImmutableArray.CreateBuilder<CultivateItemView>(items.Length);
 
                 foreach (ref readonly CultivateItem cultivateItem in items.AsSpan())
@@ -265,6 +270,34 @@ internal sealed partial class CultivationService : ICultivationService
 
         await taskContext.SwitchToBackgroundAsync();
         return cultivationRepository.TryGetAvatarCultivateEntryInnerId(projects.CurrentItem.InnerId, avatarId);
+    }
+
+    public async ValueTask<Guid?> EnsureAvatarAssociationStubAsync(uint avatarId, LevelInformation levelInformation)
+    {
+        IAdvancedDbCollectionView<CultivateProject> projects = await GetProjectCollectionAsync().ConfigureAwait(false);
+        if (!await EnsureCurrentProjectAsync(projects).ConfigureAwait(false))
+        {
+            return null;
+        }
+
+        ArgumentNullException.ThrowIfNull(projects.CurrentItem);
+
+        await taskContext.SwitchToBackgroundAsync();
+
+        Guid projectId = projects.CurrentItem.InnerId;
+        if (cultivationRepository.TryGetAvatarCultivateEntryInnerId(projectId, avatarId) is Guid existing)
+        {
+            return existing;
+        }
+
+        CultivateEntry entry = CultivateEntry.From(projectId, CultivateType.AvatarAndSkill, avatarId);
+        cultivationRepository.AddCultivateEntry(entry);
+
+        CultivateEntryLevelInformation level = CultivateEntryLevelInformation.From(entry.InnerId, CultivateType.AvatarAndSkill, levelInformation);
+        cultivationRepository.AddLevelInformation(level);
+
+        entryCollectionCache.TryRemove(projectId, out _);
+        return entry.InnerId;
     }
 
     public async ValueTask<ProjectAddResultKind> TryAddProjectAsync(CultivateProject project)
@@ -482,5 +515,26 @@ internal sealed partial class CultivationService : ICultivationService
 
         string avatarName = context.GetAvatarItem(related.Id).Name;
         return $"{avatarName}·{weaponName}";
+    }
+
+    /// <summary>
+    /// 无材料的「已满配」角色占位行不在养成列表展示（仍为武器的 RelatedEntryId 解析目标）。
+    /// </summary>
+    private static bool IsHiddenAssociationOnlyAvatarEntry(CultivateEntry entry, int cultivateItemCount)
+    {
+        if (entry.Type is not CultivateType.AvatarAndSkill || cultivateItemCount != 0)
+        {
+            return false;
+        }
+
+        if (entry.LevelInformation is not CultivateEntryLevelInformation li)
+        {
+            return false;
+        }
+
+        return li.AvatarLevelFrom == li.AvatarLevelTo
+            && li.SkillALevelFrom == li.SkillALevelTo
+            && li.SkillELevelFrom == li.SkillELevelTo
+            && li.SkillQLevelFrom == li.SkillQLevelTo;
     }
 }

--- a/src/Snap.Hutao/Snap.Hutao/Service/Cultivation/CultivationService.cs
+++ b/src/Snap.Hutao/Snap.Hutao/Service/Cultivation/CultivationService.cs
@@ -67,6 +67,12 @@ internal sealed partial class CultivationService : ICultivationService
         {
             ImmutableArray<CultivateEntry> entries = cultivationRepository.GetCultivateEntryImmutableArrayIncludingLevelInformationByProjectId(cultivateProject.InnerId);
 
+            Dictionary<Guid, CultivateEntry> entryByInnerId = new(entries.Length);
+            foreach (ref readonly CultivateEntry entry in entries.AsSpan())
+            {
+                entryByInnerId[entry.InnerId] = entry;
+            }
+
             List<CultivateEntryView> resultEntries = new(entries.Length);
             foreach (ref readonly CultivateEntry entry in entries.AsSpan())
             {
@@ -87,7 +93,13 @@ internal sealed partial class CultivationService : ICultivationService
                     _ => default!,
                 };
 
-                resultEntries.Add(CultivateEntryView.Create(entry, item, entryItems.ToImmutable()));
+                string? relatedAvatarName = null;
+                if (entry.Type is CultivateType.Weapon && entry.RelatedEntryId is Guid relatedId && entryByInnerId.TryGetValue(relatedId, out CultivateEntry? relatedEntry) && relatedEntry.Type is CultivateType.AvatarAndSkill)
+                {
+                    relatedAvatarName = context.GetAvatarItem(relatedEntry.Id).Name;
+                }
+
+                resultEntries.Add(CultivateEntryView.Create(entry, item, entryItems.ToImmutable(), relatedAvatarName));
             }
 
             ObservableCollection<CultivateEntryView> result = resultEntries.SortByDescending(e => e.IsToday).ToObservableCollection();
@@ -156,13 +168,13 @@ internal sealed partial class CultivationService : ICultivationService
         cultivationRepository.UpdateCultivateItem(item.Entity);
     }
 
-    public async ValueTask<ConsumptionSaveResultKind> SaveConsumptionAsync(InputConsumption inputConsumption)
+    public async ValueTask<ConsumptionSaveResult> SaveConsumptionAsync(InputConsumption inputConsumption)
     {
         // No selected project
         IAdvancedDbCollectionView<CultivateProject> projects = await GetProjectCollectionAsync().ConfigureAwait(false);
         if (!await EnsureCurrentProjectAsync(projects).ConfigureAwait(false))
         {
-            return ConsumptionSaveResultKind.NoProject;
+            return new(ConsumptionSaveResultKind.NoProject);
         }
 
         ArgumentNullException.ThrowIfNull(projects.CurrentItem);
@@ -172,7 +184,7 @@ internal sealed partial class CultivationService : ICultivationService
         // PreserveExisting or CreateNewEntry, but no item
         if (inputConsumption is { Strategy: not ConsumptionSaveStrategyKind.OverwriteExisting, Items: [] })
         {
-            return ConsumptionSaveResultKind.NoItem;
+            return new(ConsumptionSaveResultKind.NoItem);
         }
 
         // PreserveExisting or OverwriteExisting
@@ -185,7 +197,7 @@ internal sealed partial class CultivationService : ICultivationService
             {
                 if (inputConsumption.Strategy is ConsumptionSaveStrategyKind.PreserveExisting)
                 {
-                    return ConsumptionSaveResultKind.Skipped;
+                    return new(ConsumptionSaveResultKind.Skipped);
                 }
 
                 if (inputConsumption.Strategy is ConsumptionSaveStrategyKind.OverwriteExisting)
@@ -199,7 +211,7 @@ internal sealed partial class CultivationService : ICultivationService
 
                     if (inputConsumption.Items is [])
                     {
-                        return ConsumptionSaveResultKind.Removed;
+                        return new(ConsumptionSaveResultKind.Removed);
                     }
                 }
             }
@@ -207,13 +219,14 @@ internal sealed partial class CultivationService : ICultivationService
             {
                 if (inputConsumption.Items is [])
                 {
-                    return ConsumptionSaveResultKind.NoItem;
+                    return new(ConsumptionSaveResultKind.NoItem);
                 }
             }
         }
 
         {
             CultivateEntry entry = CultivateEntry.From(projects.CurrentItem.InnerId, inputConsumption.Type, inputConsumption.ItemId);
+            entry.RelatedEntryId = inputConsumption.RelatedEntryId;
             cultivationRepository.AddCultivateEntry(entry);
 
             CultivateEntryLevelInformation entryLevelInformation = CultivateEntryLevelInformation.From(entry.InnerId, inputConsumption.Type, inputConsumption.LevelInformation);
@@ -225,9 +238,23 @@ internal sealed partial class CultivationService : ICultivationService
             // The consumption save operation is always performed outside cultivation page
             // and without touching the cache. So we have to invalidate the cache manually.
             entryCollectionCache.TryRemove(projects.CurrentItem.InnerId, out _);
+
+            return new(ConsumptionSaveResultKind.Added, entry.InnerId);
+        }
+    }
+
+    public async ValueTask<Guid?> TryGetAvatarCultivateEntryInnerIdAsync(uint avatarId)
+    {
+        IAdvancedDbCollectionView<CultivateProject> projects = await GetProjectCollectionAsync().ConfigureAwait(false);
+        if (!await EnsureCurrentProjectAsync(projects).ConfigureAwait(false))
+        {
+            return null;
         }
 
-        return ConsumptionSaveResultKind.Added;
+        ArgumentNullException.ThrowIfNull(projects.CurrentItem);
+
+        await taskContext.SwitchToBackgroundAsync();
+        return cultivationRepository.TryGetAvatarCultivateEntryInnerId(projects.CurrentItem.InnerId, avatarId);
     }
 
     public async ValueTask<ProjectAddResultKind> TryAddProjectAsync(CultivateProject project)

--- a/src/Snap.Hutao/Snap.Hutao/Service/Cultivation/CultivationService.cs
+++ b/src/Snap.Hutao/Snap.Hutao/Service/Cultivation/CultivationService.cs
@@ -110,18 +110,23 @@ internal sealed partial class CultivationService : ICultivationService
 
     public async ValueTask<StatisticsCultivateItemCollection> GetStatisticsCultivateItemCollectionAsync(CultivateProject cultivateProject, ICultivationMetadataContext context, CultivationStatisticsMergeOptions mergeOptions, CancellationToken token)
     {
+        token.ThrowIfCancellationRequested();
         await taskContext.SwitchToBackgroundAsync();
-        return SynchronizedGetStatisticsCultivateItemCollection(cultivateProject, context, mergeOptions);
+        token.ThrowIfCancellationRequested();
+        return SynchronizedGetStatisticsCultivateItemCollection(cultivateProject, context, mergeOptions, token);
 
-        StatisticsCultivateItemCollection SynchronizedGetStatisticsCultivateItemCollection(CultivateProject cultivateProject, ICultivationMetadataContext context, CultivationStatisticsMergeOptions mergeOptions)
+        StatisticsCultivateItemCollection SynchronizedGetStatisticsCultivateItemCollection(CultivateProject cultivateProject, ICultivationMetadataContext context, CultivationStatisticsMergeOptions mergeOptions, CancellationToken token)
         {
+            token.ThrowIfCancellationRequested();
             Dictionary</* ItemId */ uint, StatisticsCultivateItem> resultItems = [];
             Guid projectId = cultivateProject.InnerId;
 
             foreach (ref readonly CultivateEntry entry in cultivationRepository.GetCultivateEntryImmutableArrayByProjectId(projectId).AsSpan())
             {
+                token.ThrowIfCancellationRequested();
                 foreach (ref readonly CultivateItem item in cultivationRepository.GetCultivateItemImmutableArrayByEntryId(entry.InnerId).AsSpan())
                 {
+                    token.ThrowIfCancellationRequested();
                     ref StatisticsCultivateItem? existedItem = ref CollectionsMarshal.GetValueRefOrAddDefault(resultItems, item.ItemId, out _);
                     if (existedItem is null || existedItem.ExcludedFromPresentation)
                     {
@@ -132,12 +137,13 @@ internal sealed partial class CultivationService : ICultivationService
                         existedItem.Count += item.Count;
                     }
 
-                    RecursiveAddMaterialIngredientsByMaterialId(cultivateProject, context, resultItems, item.ItemId);
+                    RecursiveAddMaterialIngredientsByMaterialId(cultivateProject, context, resultItems, item.ItemId, token);
                 }
             }
 
             foreach (ref readonly InventoryItem inventoryItem in inventoryRepository.GetInventoryItemImmutableArrayByProjectId(projectId).AsSpan())
             {
+                token.ThrowIfCancellationRequested();
                 ref StatisticsCultivateItem existedItem = ref CollectionsMarshal.GetValueRefOrNullRef(resultItems, inventoryItem.ItemId);
                 if (!Unsafe.IsNullRef(in existedItem))
                 {
@@ -146,7 +152,7 @@ internal sealed partial class CultivationService : ICultivationService
             }
 
             CultivationStatisticsSurplusMerge.Apply(resultItems, context, mergeOptions);
-            ApplyStatisticsConsumerMenuLines(resultItems, projectId, context, cultivationRepository);
+            ApplyStatisticsConsumerMenuLines(resultItems, projectId, context, cultivationRepository, token);
 
             return new(resultItems);
         }
@@ -314,8 +320,10 @@ internal sealed partial class CultivationService : ICultivationService
         return true;
     }
 
-    private static void RecursiveAddMaterialIngredientsByMaterialId(CultivateProject cultivateProject, ICultivationMetadataContext context, Dictionary<uint, StatisticsCultivateItem> resultItems, MaterialId materialId)
+    private static void RecursiveAddMaterialIngredientsByMaterialId(CultivateProject cultivateProject, ICultivationMetadataContext context, Dictionary<uint, StatisticsCultivateItem> resultItems, MaterialId materialId, CancellationToken token)
     {
+        token.ThrowIfCancellationRequested();
+
         if (materialId == 104003U)
         {
             foreach (ref readonly MaterialId xpBookId in (ReadOnlySpan<MaterialId>)[104001U, 104002U])
@@ -331,9 +339,10 @@ internal sealed partial class CultivationService : ICultivationService
         {
             foreach (ref readonly IdCount ingredient in combine.Materials.AsSpan())
             {
+                token.ThrowIfCancellationRequested();
                 ref StatisticsCultivateItem? ingredientItem = ref CollectionsMarshal.GetValueRefOrAddDefault(resultItems, ingredient.Id, out _);
                 ingredientItem ??= StatisticsCultivateItem.Create(context.GetMaterial(ingredient.Id), cultivateProject.ServerTimeZoneOffset);
-                RecursiveAddMaterialIngredientsByMaterialId(cultivateProject, context, resultItems, ingredient.Id);
+                RecursiveAddMaterialIngredientsByMaterialId(cultivateProject, context, resultItems, ingredient.Id, token);
             }
         }
     }
@@ -342,8 +351,10 @@ internal sealed partial class CultivationService : ICultivationService
         Dictionary<uint, StatisticsCultivateItem> resultItems,
         Guid projectId,
         ICultivationMetadataContext context,
-        ICultivationRepository cultivationRepository)
+        ICultivationRepository cultivationRepository,
+        CancellationToken token)
     {
+        token.ThrowIfCancellationRequested();
         ImmutableArray<(CultivateEntry Entry, CultivateItem Item)> pairs = cultivationRepository.GetCultivateEntryItemPairsByProjectId(projectId);
         ImmutableArray<CultivateEntry> projectEntries = cultivationRepository.GetCultivateEntryImmutableArrayByProjectId(projectId);
         Dictionary<Guid, CultivateEntry> entryByInnerId = new(projectEntries.Length);
@@ -356,6 +367,7 @@ internal sealed partial class CultivationService : ICultivationService
 
         foreach ((CultivateEntry entry, CultivateItem item) in pairs.AsSpan())
         {
+            token.ThrowIfCancellationRequested();
             if (item.IsFinished)
             {
                 continue;
@@ -370,6 +382,7 @@ internal sealed partial class CultivationService : ICultivationService
 
         foreach ((uint materialId, StatisticsCultivateItem stat) in resultItems)
         {
+            token.ThrowIfCancellationRequested();
             if (MaterialIds.IsExcludedFromStatisticsConsumerMenu(materialId))
             {
                 stat.StatisticsConsumerMenuLines = ImmutableArray.Create(StatisticsConsumerMenuLine.Plain(SH.ViewPageCultivationStatisticsConsumerMenuExcluded));

--- a/src/Snap.Hutao/Snap.Hutao/Service/Cultivation/CultivationService.cs
+++ b/src/Snap.Hutao/Snap.Hutao/Service/Cultivation/CultivationService.cs
@@ -15,7 +15,6 @@ using Snap.Hutao.Service.Metadata.ContextAbstraction;
 using Snap.Hutao.ViewModel.Cultivation;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Collections.Immutable;
 using System.Collections.ObjectModel;
 using System.Linq;
@@ -135,7 +134,7 @@ internal sealed partial class CultivationService : ICultivationService
             }
 
             CultivationStatisticsSurplusMerge.Apply(resultItems, context, mergeOptions);
-            ApplyStatisticsConsumerMenuText(resultItems, projectId, context, cultivationRepository);
+            ApplyStatisticsConsumerMenuLines(resultItems, projectId, context, cultivationRepository);
 
             return new(resultItems);
         }
@@ -312,7 +311,7 @@ internal sealed partial class CultivationService : ICultivationService
         }
     }
 
-    private static void ApplyStatisticsConsumerMenuText(
+    private static void ApplyStatisticsConsumerMenuLines(
         Dictionary<uint, StatisticsCultivateItem> resultItems,
         Guid projectId,
         ICultivationMetadataContext context,
@@ -339,24 +338,18 @@ internal sealed partial class CultivationService : ICultivationService
         {
             if (MaterialIds.IsExcludedFromStatisticsConsumerMenu(materialId))
             {
-                stat.StatisticsConsumerMenuText = SH.ViewPageCultivationStatisticsConsumerMenuExcluded;
+                stat.StatisticsConsumerMenuLines = ImmutableArray.Create(SH.ViewPageCultivationStatisticsConsumerMenuExcluded);
                 continue;
             }
 
             if (unfinishedSegmentsByMaterial.TryGetValue(materialId, out List<string>? segments))
             {
                 segments.Sort(StringComparer.Ordinal);
-                stat.StatisticsConsumerMenuText = string.Format(
-                    CultureInfo.CurrentCulture,
-                    SH.ViewPageCultivationStatisticsUnfinishedConsumers,
-                    string.Join('，', segments));
+                stat.StatisticsConsumerMenuLines = ImmutableArray.CreateRange(segments);
             }
             else
             {
-                stat.StatisticsConsumerMenuText = string.Format(
-                    CultureInfo.CurrentCulture,
-                    SH.ViewPageCultivationStatisticsUnfinishedConsumers,
-                    SH.ViewPageCultivationStatisticsUnfinishedConsumersEmptyList);
+                stat.StatisticsConsumerMenuLines = ImmutableArray.Create(SH.ViewPageCultivationStatisticsUnfinishedConsumersEmptyList);
             }
         }
     }

--- a/src/Snap.Hutao/Snap.Hutao/Service/Cultivation/CultivationService.cs
+++ b/src/Snap.Hutao/Snap.Hutao/Service/Cultivation/CultivationService.cs
@@ -2,13 +2,16 @@
 // Licensed under the MIT license.
 
 using Snap.Hutao.Core.Database;
+using Snap.Hutao.Core.Text.Json;
 using Snap.Hutao.Model;
+using Snap.Hutao.Model.Cultivation;
 using Snap.Hutao.Model.Entity;
 using Snap.Hutao.Model.Entity.Primitive;
 using Snap.Hutao.Model.Intrinsic;
 using Snap.Hutao.Model.Metadata;
 using Snap.Hutao.Model.Metadata.Item;
 using Snap.Hutao.Model.Primitive;
+using Snap.Hutao.Service.Abstraction;
 using Snap.Hutao.Service.Cultivation.Consumption;
 using Snap.Hutao.Service.Inventory;
 using Snap.Hutao.Service.Metadata.ContextAbstraction;
@@ -20,6 +23,7 @@ using System.Collections.ObjectModel;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Text.Json;
 using ModelItem = Snap.Hutao.Model.Item;
 
 namespace Snap.Hutao.Service.Cultivation;
@@ -361,6 +365,50 @@ internal sealed partial class CultivationService : ICultivationService
         projects.MoveCurrentTo(project);
 
         return ProjectAddResultKind.Added;
+    }
+
+    public async ValueTask<CultivateProjectAvatarPropertyBatchPreferences?> GetAvatarPropertyBatchCultivatePreferencesForCurrentProjectAsync()
+    {
+        IAdvancedDbCollectionView<CultivateProject> projects = await GetProjectCollectionAsync().ConfigureAwait(false);
+        if (!await EnsureCurrentProjectAsync(projects).ConfigureAwait(false))
+        {
+            return null;
+        }
+
+        string? json = projects.CurrentItem?.AvatarPropertyBatchCultivatePreferencesJson;
+        if (string.IsNullOrWhiteSpace(json))
+        {
+            return null;
+        }
+
+        try
+        {
+            return JsonSerializer.Deserialize<CultivateProjectAvatarPropertyBatchPreferences>(json, JsonOptions.Default);
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+
+    public async ValueTask SaveAvatarPropertyBatchCultivatePreferencesForCurrentProjectAsync(CultivateProjectAvatarPropertyBatchPreferences preferences)
+    {
+        ArgumentNullException.ThrowIfNull(preferences);
+
+        IAdvancedDbCollectionView<CultivateProject> projects = await GetProjectCollectionAsync().ConfigureAwait(false);
+        if (!await EnsureCurrentProjectAsync(projects).ConfigureAwait(false))
+        {
+            return;
+        }
+
+        ArgumentNullException.ThrowIfNull(projects.CurrentItem);
+
+        CultivateProject project = projects.CurrentItem;
+
+        await taskContext.SwitchToBackgroundAsync();
+
+        project.AvatarPropertyBatchCultivatePreferencesJson = JsonSerializer.Serialize(preferences, JsonOptions.Default);
+        cultivationRepository.Update(project);
     }
 
     public async ValueTask RemoveProjectAsync(CultivateProject project)

--- a/src/Snap.Hutao/Snap.Hutao/Service/Cultivation/CultivationService.cs
+++ b/src/Snap.Hutao/Snap.Hutao/Service/Cultivation/CultivationService.cs
@@ -345,6 +345,13 @@ internal sealed partial class CultivationService : ICultivationService
         ICultivationRepository cultivationRepository)
     {
         ImmutableArray<(CultivateEntry Entry, CultivateItem Item)> pairs = cultivationRepository.GetCultivateEntryItemPairsByProjectId(projectId);
+        ImmutableArray<CultivateEntry> projectEntries = cultivationRepository.GetCultivateEntryImmutableArrayByProjectId(projectId);
+        Dictionary<Guid, CultivateEntry> entryByInnerId = new(projectEntries.Length);
+        foreach (ref readonly CultivateEntry e in projectEntries.AsSpan())
+        {
+            entryByInnerId[e.InnerId] = e;
+        }
+
         Dictionary<uint, List<string>> unfinishedSegmentsByMaterial = [];
 
         foreach ((CultivateEntry entry, CultivateItem item) in pairs.AsSpan())
@@ -354,7 +361,7 @@ internal sealed partial class CultivationService : ICultivationService
                 continue;
             }
 
-            string name = FormatStatisticsConsumerEntryName(entry, context);
+            string name = FormatStatisticsConsumerEntryName(entry, context, entryByInnerId);
             string segment = $"{name}×{item.Count}";
             ref List<string>? list = ref CollectionsMarshal.GetValueRefOrAddDefault(unfinishedSegmentsByMaterial, item.ItemId, out _);
             list ??= [];
@@ -381,13 +388,39 @@ internal sealed partial class CultivationService : ICultivationService
         }
     }
 
-    private static string FormatStatisticsConsumerEntryName(CultivateEntry entry, ICultivationMetadataContext context)
+    private static string FormatStatisticsConsumerEntryName(
+        CultivateEntry entry,
+        ICultivationMetadataContext context,
+        Dictionary<Guid, CultivateEntry> entryByInnerId)
     {
         return entry.Type switch
         {
             CultivateType.AvatarAndSkill => context.GetAvatarItem(entry.Id).Name,
-            CultivateType.Weapon => context.GetWeaponItem(entry.Id).Name,
+            CultivateType.Weapon => FormatStatisticsConsumerWeaponEntryName(entry, context, entryByInnerId),
             _ => Material.Default.Name,
         };
+    }
+
+    /// <summary>
+    /// 材料统计右键「未完成」：武器条目在有关联角色条目时展示「角色名·武器名」，否则（含历史无 RelatedEntryId）仅武器名。
+    /// </summary>
+    private static string FormatStatisticsConsumerWeaponEntryName(
+        CultivateEntry entry,
+        ICultivationMetadataContext context,
+        Dictionary<Guid, CultivateEntry> entryByInnerId)
+    {
+        string weaponName = context.GetWeaponItem(entry.Id).Name;
+        if (entry.RelatedEntryId is not Guid relatedId)
+        {
+            return weaponName;
+        }
+
+        if (!entryByInnerId.TryGetValue(relatedId, out CultivateEntry? related) || related.Type is not CultivateType.AvatarAndSkill)
+        {
+            return weaponName;
+        }
+
+        string avatarName = context.GetAvatarItem(related.Id).Name;
+        return $"{avatarName}·{weaponName}";
     }
 }

--- a/src/Snap.Hutao/Snap.Hutao/Service/Cultivation/CultivationStatisticsMergeOptions.cs
+++ b/src/Snap.Hutao/Snap.Hutao/Service/Cultivation/CultivationStatisticsMergeOptions.cs
@@ -3,4 +3,7 @@
 
 namespace Snap.Hutao.Service.Cultivation;
 
-internal readonly record struct CultivationStatisticsMergeOptions(bool MergeUpgradeMaterials, bool TalentSynthCritTenPercent);
+internal readonly record struct CultivationStatisticsMergeOptions(
+    bool MergeUpgradeMaterials,
+    bool TalentSynthCritTenPercent,
+    bool WeeklyBossMaterialInterchange);

--- a/src/Snap.Hutao/Snap.Hutao/Service/Cultivation/CultivationStatisticsMergeOptions.cs
+++ b/src/Snap.Hutao/Snap.Hutao/Service/Cultivation/CultivationStatisticsMergeOptions.cs
@@ -1,0 +1,6 @@
+// Copyright (c) DGP Studio. All rights reserved.
+// Licensed under the MIT license.
+
+namespace Snap.Hutao.Service.Cultivation;
+
+internal readonly record struct CultivationStatisticsMergeOptions(bool MergeUpgradeMaterials, bool TalentSynthCritTenPercent);

--- a/src/Snap.Hutao/Snap.Hutao/Service/Cultivation/CultivationStatisticsSurplusMerge.cs
+++ b/src/Snap.Hutao/Snap.Hutao/Service/Cultivation/CultivationStatisticsSurplusMerge.cs
@@ -10,7 +10,13 @@ namespace Snap.Hutao.Service.Cultivation;
 
 internal static class CultivationStatisticsSurplusMerge
 {
-    private const uint TalentCombineType = 3U;
+    /// <summary>
+    /// 元数据 <c>Combine.Type</c>：1 角色与武器培养素材（野怪等）、2 武器突破、3 角色天赋；与此三类对应的合成均支持 10% 暴击期望。
+    /// </summary>
+    private static bool CombineTypeSupportsSynthCritTenPercent(uint combineType)
+    {
+        return combineType is 1U or 2U or 3U;
+    }
 
     public static void Apply(Dictionary<uint, StatisticsCultivateItem> items, ICultivationMetadataContext context, CultivationStatisticsMergeOptions options)
     {
@@ -76,7 +82,7 @@ internal static class CultivationStatisticsSurplusMerge
                     continue;
                 }
 
-                double multiplier = talentCrit && upward.Type == TalentCombineType ? 1.1D : 1D;
+                double multiplier = talentCrit && CombineTypeSupportsSynthCritTenPercent(upward.Type) ? 1.1D : 1D;
                 double produced = crafts * multiplier;
                 uint resultId = upward.Result.Id;
 

--- a/src/Snap.Hutao/Snap.Hutao/Service/Cultivation/CultivationStatisticsSurplusMerge.cs
+++ b/src/Snap.Hutao/Snap.Hutao/Service/Cultivation/CultivationStatisticsSurplusMerge.cs
@@ -1,0 +1,120 @@
+// Copyright (c) DGP Studio. All rights reserved.
+// Licensed under the MIT license.
+
+using Snap.Hutao.Model.Intrinsic;
+using Snap.Hutao.Model.Metadata;
+using Snap.Hutao.Service.Metadata.ContextAbstraction;
+using Snap.Hutao.ViewModel.Cultivation;
+
+namespace Snap.Hutao.Service.Cultivation;
+
+internal static class CultivationStatisticsSurplusMerge
+{
+    private const uint TalentCombineType = 3U;
+
+    public static void Apply(Dictionary<uint, StatisticsCultivateItem> items, ICultivationMetadataContext context, CultivationStatisticsMergeOptions options)
+    {
+        if (!options.MergeUpgradeMaterials || items.Count is 0)
+        {
+            return;
+        }
+
+        bool talentCrit = options.TalentSynthCritTenPercent;
+
+        List<Combine> eligibleCombines = [];
+        foreach (Combine combine in context.ResultMaterialIdCombineMap.Values)
+        {
+            if (combine.RecipeType is not RecipeType.RECIPE_TYPE_COMBINE)
+            {
+                continue;
+            }
+
+            if (combine.Materials.Length is not 1 || combine.Materials[0].Count is not 3 || combine.Result.Count is not 1)
+            {
+                continue;
+            }
+
+            eligibleCombines.Add(combine);
+        }
+
+        Dictionary<uint, double> virtualAmount = new(items.Count);
+        foreach ((uint id, StatisticsCultivateItem item) in items)
+        {
+            virtualAmount[id] = item.Current;
+        }
+
+        foreach (IGrouping<uint, Combine> group in eligibleCombines.GroupBy(static c => c.SubType))
+        {
+            List<Combine> groupCombines = [.. group];
+            HashSet<uint> ids = [];
+            foreach (Combine combine in groupCombines)
+            {
+                _ = ids.Add(combine.Result.Id);
+                _ = ids.Add(combine.Materials[0].Id);
+            }
+
+            uint[] sortedIds = [.. ids.OrderBy(id => GetRankLevel(context, id)).ThenBy(id => id)];
+
+            foreach (uint id in sortedIds)
+            {
+                Combine? upward = FindUpwardCombine(groupCombines, id);
+                if (upward is null)
+                {
+                    continue;
+                }
+
+                if (!virtualAmount.TryGetValue(id, out double virt))
+                {
+                    continue;
+                }
+
+                uint need = items.TryGetValue(id, out StatisticsCultivateItem? row) ? row.Count : 0U;
+                double surplus = Math.Max(0D, virt - need);
+                long crafts = (long)(surplus / 3D);
+                if (crafts <= 0L)
+                {
+                    continue;
+                }
+
+                double multiplier = talentCrit && upward.Type == TalentCombineType ? 1.1D : 1D;
+                double produced = crafts * multiplier;
+                uint resultId = upward.Result.Id;
+
+                virtualAmount[id] = virt - (crafts * 3L);
+
+                if (!virtualAmount.TryGetValue(resultId, out double atResult))
+                {
+                    atResult = items.TryGetValue(resultId, out StatisticsCultivateItem? r) ? r.Current : 0D;
+                }
+
+                virtualAmount[resultId] = atResult + produced;
+            }
+        }
+
+        foreach ((uint id, StatisticsCultivateItem item) in items)
+        {
+            if (virtualAmount.TryGetValue(id, out double v))
+            {
+                item.MergeAdjustedCurrent = (uint)Math.Clamp(Math.Floor(v + 1e-6), 0D, uint.MaxValue);
+            }
+        }
+    }
+
+    private static Combine? FindUpwardCombine(List<Combine> groupCombines, uint ingredientId)
+    {
+        foreach (Combine combine in groupCombines)
+        {
+            if (combine.Materials is [{ Id: var mid, Count: 3 }] && mid == ingredientId)
+            {
+                return combine;
+            }
+        }
+
+        return null;
+    }
+
+    private static QualityType GetRankLevel(ICultivationMetadataContext context, uint materialId)
+    {
+        return context.GetMaterial(materialId).RankLevel;
+    }
+}

--- a/src/Snap.Hutao/Snap.Hutao/Service/Cultivation/CultivationStatisticsWeeklyBossInterchange.cs
+++ b/src/Snap.Hutao/Snap.Hutao/Service/Cultivation/CultivationStatisticsWeeklyBossInterchange.cs
@@ -1,0 +1,109 @@
+// Copyright (c) DGP Studio. All rights reserved.
+// Licensed under the MIT license.
+
+using Snap.Hutao.Model.Primitive;
+using Snap.Hutao.ViewModel.Cultivation;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+
+namespace Snap.Hutao.Service.Cultivation;
+
+/// <summary>
+/// 材料统计：同一周本 Boss 材料池内，将超出需求的虚拟持有量 1:1 调配给池内缺口（不计异梦溶媒消耗）。
+/// </summary>
+internal static class CultivationStatisticsWeeklyBossInterchange
+{
+    public static void Apply(
+        Dictionary<uint, StatisticsCultivateItem> items,
+        ImmutableArray<ImmutableArray<MaterialId>> interchangeGroups,
+        bool enabled)
+    {
+        if (!enabled || interchangeGroups.IsDefault || interchangeGroups.IsEmpty)
+        {
+            return;
+        }
+
+        foreach (ImmutableArray<MaterialId> group in interchangeGroups)
+        {
+            ApplySingleGroup(items, group);
+        }
+    }
+
+    private static void ApplySingleGroup(Dictionary<uint, StatisticsCultivateItem> items, ImmutableArray<MaterialId> group)
+    {
+        List<uint> poolIds = [];
+        foreach (MaterialId mid in group)
+        {
+            uint id = mid;
+            if (items.ContainsKey(id))
+            {
+                poolIds.Add(id);
+            }
+        }
+
+        if (poolIds.Count < 2)
+        {
+            return;
+        }
+
+        Dictionary<uint, uint> virt = new(poolIds.Count);
+        foreach (uint id in poolIds)
+        {
+            StatisticsCultivateItem it = items[id];
+            virt[id] = it.MergeAdjustedCurrent ?? it.Current;
+        }
+
+        while (true)
+        {
+            uint? donor = null;
+            uint maxSurplus = 0U;
+            foreach (uint id in poolIds)
+            {
+                uint v = virt[id];
+                uint need = items[id].Count;
+                if (v > need && v - need > maxSurplus)
+                {
+                    maxSurplus = v - need;
+                    donor = id;
+                }
+            }
+
+            uint? receiver = null;
+            uint maxDeficit = 0U;
+            foreach (uint id in poolIds)
+            {
+                if (id == donor)
+                {
+                    continue;
+                }
+
+                uint v = virt[id];
+                uint need = items[id].Count;
+                if (v < need && need - v > maxDeficit)
+                {
+                    maxDeficit = need - v;
+                    receiver = id;
+                }
+            }
+
+            if (donor is null || receiver is null || maxSurplus is 0U || maxDeficit is 0U)
+            {
+                break;
+            }
+
+            virt[donor.Value]--;
+            virt[receiver.Value]++;
+        }
+
+        foreach (uint id in poolIds)
+        {
+            StatisticsCultivateItem it = items[id];
+            uint baseline = it.MergeAdjustedCurrent ?? it.Current;
+            uint finalV = virt[id];
+            if (finalV != baseline)
+            {
+                it.WeeklyBossInterchangeAdjustedCurrent = finalV;
+            }
+        }
+    }
+}

--- a/src/Snap.Hutao/Snap.Hutao/Service/Cultivation/IAvatarPropertyBatchCultivateService.cs
+++ b/src/Snap.Hutao/Snap.Hutao/Service/Cultivation/IAvatarPropertyBatchCultivateService.cs
@@ -1,0 +1,16 @@
+// Copyright (c) DGP Studio. All rights reserved.
+// Licensed under the MIT license.
+
+using Snap.Hutao.Service.AvatarInfo.Factory;
+using Snap.Hutao.ViewModel.AvatarProperty;
+using System.Collections.Immutable;
+
+namespace Snap.Hutao.Service.Cultivation;
+
+internal interface IAvatarPropertyBatchCultivateService
+{
+    /// <summary>
+    /// <see langword="null"/> when the baseline dialog is dismissed without confirmation.
+    /// </summary>
+    ValueTask<BatchCultivateResult?> ExecuteAsync(SummaryFactoryMetadataContext metadataContext, ImmutableArray<AvatarView> targetAvatars, CancellationToken cancellationToken);
+}

--- a/src/Snap.Hutao/Snap.Hutao/Service/Cultivation/ICultivationMetadataContext.cs
+++ b/src/Snap.Hutao/Snap.Hutao/Service/Cultivation/ICultivationMetadataContext.cs
@@ -14,7 +14,8 @@ internal interface ICultivationMetadataContext : IMetadataContext,
     IMetadataDictionaryIdMaterialSource,
     IMetadataDictionaryIdAvatarSource,
     IMetadataDictionaryIdWeaponSource,
-    IMetadataDictionaryResultMaterialIdCombineSource
+    IMetadataDictionaryResultMaterialIdCombineSource,
+    IMetadataWeeklyBossMaterialInterchangeGroupsSource
 {
     Item GetAvatarItem(AvatarId avatarId);
 

--- a/src/Snap.Hutao/Snap.Hutao/Service/Cultivation/ICultivationRepository.cs
+++ b/src/Snap.Hutao/Snap.Hutao/Service/Cultivation/ICultivationRepository.cs
@@ -43,6 +43,12 @@ internal interface ICultivationRepository : IRepository<CultivateEntryLevelInfor
 
     ImmutableArray<CultivateEntry> GetCultivateEntryImmutableArrayByProjectIdAndItemId(Guid projectId, uint itemId);
 
+    /// <summary>
+    /// 解析当前计划中指定角色的养成条目（类型为 CultivateType.AvatarAndSkill）。
+    /// 若存在多条历史记录，取条目主键 InnerId（Guid）较大的一条。
+    /// </summary>
+    Guid? TryGetAvatarCultivateEntryInnerId(Guid projectId, uint avatarId);
+
     Guid GetCultivateProjectIdByEntryId(Guid entryId);
 
     /// <summary>

--- a/src/Snap.Hutao/Snap.Hutao/Service/Cultivation/ICultivationRepository.cs
+++ b/src/Snap.Hutao/Snap.Hutao/Service/Cultivation/ICultivationRepository.cs
@@ -47,7 +47,7 @@ internal interface ICultivationRepository : IRepository<CultivateEntryLevelInfor
 
     /// <summary>
     /// 解析当前计划中指定角色的养成条目（类型为 CultivateType.AvatarAndSkill）。
-    /// 若存在多条历史记录，取条目主键 InnerId（Guid）较大的一条。
+    /// 若存在多条历史记录，取最近插入数据库的一条（按 SQLite rowid 倒序）。
     /// </summary>
     Guid? TryGetAvatarCultivateEntryInnerId(Guid projectId, uint avatarId);
 

--- a/src/Snap.Hutao/Snap.Hutao/Service/Cultivation/ICultivationRepository.cs
+++ b/src/Snap.Hutao/Snap.Hutao/Service/Cultivation/ICultivationRepository.cs
@@ -44,4 +44,9 @@ internal interface ICultivationRepository : IRepository<CultivateEntryLevelInfor
     ImmutableArray<CultivateEntry> GetCultivateEntryImmutableArrayByProjectIdAndItemId(Guid projectId, uint itemId);
 
     Guid GetCultivateProjectIdByEntryId(Guid entryId);
+
+    /// <summary>
+    /// 联表查询某计划下所有养成物品及其所属条目（用于材料统计未勾选条目等）。
+    /// </summary>
+    ImmutableArray<(CultivateEntry Entry, CultivateItem Item)> GetCultivateEntryItemPairsByProjectId(Guid projectId);
 }

--- a/src/Snap.Hutao/Snap.Hutao/Service/Cultivation/ICultivationRepository.cs
+++ b/src/Snap.Hutao/Snap.Hutao/Service/Cultivation/ICultivationRepository.cs
@@ -27,6 +27,8 @@ internal interface ICultivationRepository : IRepository<CultivateEntryLevelInfor
 
     ObservableCollection<CultivateProject> GetCultivateProjectCollection();
 
+    ImmutableArray<Guid> GetCultivateProjectInnerIds();
+
     CultivateProject? GetCultivateProjectById(Guid projectId);
 
     void AddCultivateEntry(CultivateEntry entry);

--- a/src/Snap.Hutao/Snap.Hutao/Service/Cultivation/ICultivationService.cs
+++ b/src/Snap.Hutao/Snap.Hutao/Service/Cultivation/ICultivationService.cs
@@ -17,7 +17,7 @@ internal interface ICultivationService
 
     ValueTask<ObservableCollection<CultivateEntryView>> GetCultivateEntryCollectionAsync(CultivateProject cultivateProject, ICultivationMetadataContext context);
 
-    ValueTask<StatisticsCultivateItemCollection> GetStatisticsCultivateItemCollectionAsync(CultivateProject cultivateProject, ICultivationMetadataContext context, CancellationToken token);
+    ValueTask<StatisticsCultivateItemCollection> GetStatisticsCultivateItemCollectionAsync(CultivateProject cultivateProject, ICultivationMetadataContext context, CultivationStatisticsMergeOptions mergeOptions, CancellationToken token);
 
     ValueTask<ResinStatistics> GetResinStatisticsAsync(StatisticsCultivateItemCollection statisticsCultivateItems, CancellationToken token);
 

--- a/src/Snap.Hutao/Snap.Hutao/Service/Cultivation/ICultivationService.cs
+++ b/src/Snap.Hutao/Snap.Hutao/Service/Cultivation/ICultivationService.cs
@@ -23,6 +23,11 @@ internal interface ICultivationService
 
     ValueTask RemoveCultivateEntryAsync(Guid entryId);
 
+    /// <summary>
+    /// 移除当前选中养成计划中角色与武器类型的全部养成条目。
+    /// </summary>
+    ValueTask RemoveAvatarAndWeaponEntriesForCurrentProjectAsync();
+
     ValueTask RemoveProjectAsync(CultivateProject project);
 
     ValueTask<ConsumptionSaveResult> SaveConsumptionAsync(InputConsumption inputConsumption);

--- a/src/Snap.Hutao/Snap.Hutao/Service/Cultivation/ICultivationService.cs
+++ b/src/Snap.Hutao/Snap.Hutao/Service/Cultivation/ICultivationService.cs
@@ -29,6 +29,12 @@ internal interface ICultivationService
 
     ValueTask<Guid?> TryGetAvatarCultivateEntryInnerIdAsync(uint avatarId);
 
+    /// <summary>
+    /// 当前计划中尚无该角色的养成条目时，插入一条无材料行的角色占位条目（等级信息与 delta 一致），供武器 RelatedEntryId 关联。
+    /// 若已存在角色条目则返回其 InnerId。
+    /// </summary>
+    ValueTask<Guid?> EnsureAvatarAssociationStubAsync(uint avatarId, LevelInformation levelInformation);
+
     void SaveCultivateItem(CultivateItemView item);
 
     ValueTask<ProjectAddResultKind> TryAddProjectAsync(CultivateProject project);

--- a/src/Snap.Hutao/Snap.Hutao/Service/Cultivation/ICultivationService.cs
+++ b/src/Snap.Hutao/Snap.Hutao/Service/Cultivation/ICultivationService.cs
@@ -25,7 +25,9 @@ internal interface ICultivationService
 
     ValueTask RemoveProjectAsync(CultivateProject project);
 
-    ValueTask<ConsumptionSaveResultKind> SaveConsumptionAsync(InputConsumption inputConsumption);
+    ValueTask<ConsumptionSaveResult> SaveConsumptionAsync(InputConsumption inputConsumption);
+
+    ValueTask<Guid?> TryGetAvatarCultivateEntryInnerIdAsync(uint avatarId);
 
     void SaveCultivateItem(CultivateItemView item);
 

--- a/src/Snap.Hutao/Snap.Hutao/Service/Cultivation/ICultivationService.cs
+++ b/src/Snap.Hutao/Snap.Hutao/Service/Cultivation/ICultivationService.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 using Snap.Hutao.Core.Database;
+using Snap.Hutao.Model.Cultivation;
 using Snap.Hutao.Model.Entity;
 using Snap.Hutao.Service.Cultivation.Consumption;
 using Snap.Hutao.ViewModel.Cultivation;
@@ -43,4 +44,14 @@ internal interface ICultivationService
     void SaveCultivateItem(CultivateItemView item);
 
     ValueTask<ProjectAddResultKind> TryAddProjectAsync(CultivateProject project);
+
+    /// <summary>
+    /// 读取当前选中养成计划下「我的角色」批量同步对话框的已保存选项；未保存时返回 <see langword="null"/>。
+    /// </summary>
+    ValueTask<CultivateProjectAvatarPropertyBatchPreferences?> GetAvatarPropertyBatchCultivatePreferencesForCurrentProjectAsync();
+
+    /// <summary>
+    /// 将批量同步对话框的选项写入当前选中养成计划。
+    /// </summary>
+    ValueTask SaveAvatarPropertyBatchCultivatePreferencesForCurrentProjectAsync(CultivateProjectAvatarPropertyBatchPreferences preferences);
 }

--- a/src/Snap.Hutao/Snap.Hutao/Service/Cultivation/InputConsumption.cs
+++ b/src/Snap.Hutao/Snap.Hutao/Service/Cultivation/InputConsumption.cs
@@ -19,4 +19,9 @@ internal sealed class InputConsumption
     public required LevelInformation LevelInformation { get; init; }
 
     public required ConsumptionSaveStrategyKind Strategy { get; init; }
+
+    /// <summary>
+    /// 武器条目关联的养成角色条目的主键（自引用外键，可为空）。
+    /// </summary>
+    public Guid? RelatedEntryId { get; init; }
 }

--- a/src/Snap.Hutao/Snap.Hutao/Service/Cultivation/StatisticsCultivateItemCollection.cs
+++ b/src/Snap.Hutao/Snap.Hutao/Service/Cultivation/StatisticsCultivateItemCollection.cs
@@ -50,7 +50,7 @@ internal sealed partial class StatisticsCultivateItemCollection : ICollection<St
                 return result;
             }
 
-            return MaterialIdComparer.Shared.Compare(x.Inner.Id, y.Inner.Id);
+            return StatisticsCultivateItemComparer.CompareCore(x, y);
         });
     }
 

--- a/src/Snap.Hutao/Snap.Hutao/Service/Cultivation/StatisticsCultivateItemComparer.cs
+++ b/src/Snap.Hutao/Snap.Hutao/Service/Cultivation/StatisticsCultivateItemComparer.cs
@@ -1,20 +1,53 @@
 // Copyright (c) DGP Studio. All rights reserved.
 // Licensed under the MIT license.
 
-using Snap.Hutao.Core.Collection.Generic;
 using Snap.Hutao.Model.Primitive;
 using Snap.Hutao.ViewModel.Cultivation;
 
 namespace Snap.Hutao.Service.Cultivation;
 
-internal sealed class StatisticsCultivateItemComparer : DelegatingPropertyComparer<StatisticsCultivateItem, MaterialId>
+/// <summary>
+/// 材料统计默认顺序：与原先一致按 <see cref="MaterialIdComparer"/>，但当两项均为「角色培养素材」时先按 <see cref="Snap.Hutao.Model.Metadata.Item.Material.RankLevel"/> 再按物品 Id。
+/// </summary>
+internal sealed class StatisticsCultivateItemComparer : IComparer<StatisticsCultivateItem>
 {
     private static readonly LazySlim<StatisticsCultivateItemComparer> LazyShared = new(() => new());
 
     private StatisticsCultivateItemComparer()
-        : base(static i => i.Inner.Id, MaterialIdComparer.Shared)
     {
     }
 
     public static StatisticsCultivateItemComparer Shared { get => LazyShared.Value; }
+
+    public int Compare(StatisticsCultivateItem? x, StatisticsCultivateItem? y)
+    {
+        return (x, y) switch
+        {
+            (null, not null) => -1,
+            (not null, null) => 1,
+            (null, null) => 0,
+            (not null, not null) => CompareCore(x, y),
+        };
+    }
+
+    internal static int CompareCore(StatisticsCultivateItem x, StatisticsCultivateItem y)
+    {
+        string? tx = x.Inner.TypeDescription;
+        string? ty = y.Inner.TypeDescription;
+        if (IsCharacterLevelUpMaterial(tx) && IsCharacterLevelUpMaterial(ty))
+        {
+            int rank = x.Inner.RankLevel.CompareTo(y.Inner.RankLevel);
+            if (rank is not 0)
+            {
+                return rank;
+            }
+        }
+
+        return MaterialIdComparer.Shared.Compare(x.Inner.Id, y.Inner.Id);
+    }
+
+    private static bool IsCharacterLevelUpMaterial(string? typeDescription)
+    {
+        return typeDescription == SH.ModelMetadataMaterialCharacterLevelUpMaterial;
+    }
 }

--- a/src/Snap.Hutao/Snap.Hutao/Service/Cultivation/WeeklyBossMaterialInterchangeGroupsBuilder.cs
+++ b/src/Snap.Hutao/Snap.Hutao/Service/Cultivation/WeeklyBossMaterialInterchangeGroupsBuilder.cs
@@ -1,0 +1,138 @@
+// Copyright (c) DGP Studio. All rights reserved.
+// Licensed under the MIT license.
+
+using Snap.Hutao.Model.Intrinsic;
+using Snap.Hutao.Model.Metadata;
+using Snap.Hutao.Model.Primitive;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+
+namespace Snap.Hutao.Service.Cultivation;
+
+/// <summary>
+/// 自 Combine 列表解析周本材料异梦转化互通组：配方为 Type=9、CONVERT、产物×1、材料为「异梦溶媒」+ 另一周本材料各×1。
+/// </summary>
+internal static class WeeklyBossMaterialInterchangeGroupsBuilder
+{
+    /// <summary>异梦溶媒 Id（转化消耗，统计虚拟调配时不扣溶媒，仅利用池内 1:1 等价）。</summary>
+    private const uint DreamSolventMaterialId = 113021U;
+
+    public static ImmutableArray<ImmutableArray<MaterialId>> Build(ImmutableArray<Combine> combines)
+    {
+        Dictionary<MaterialId, HashSet<MaterialId>> adjacency = [];
+
+        foreach (Combine combine in combines)
+        {
+            if (combine.Type is not 9U)
+            {
+                continue;
+            }
+
+            if (combine.RecipeType is not RecipeType.RECIPE_TYPE_CONVERT)
+            {
+                continue;
+            }
+
+            if (combine.Materials.Length is not 2 || combine.Result.Count is not 1)
+            {
+                continue;
+            }
+
+            MaterialId resultId = combine.Result.Id;
+            MaterialId? otherMaterial = null;
+            foreach (ref readonly IdCount m in combine.Materials.AsSpan())
+            {
+                if (m.Id == DreamSolventMaterialId)
+                {
+                    continue;
+                }
+
+                if (m.Count is not 1)
+                {
+                    otherMaterial = null;
+                    break;
+                }
+
+                otherMaterial = m.Id;
+            }
+
+            if (otherMaterial is null || otherMaterial.Value == resultId)
+            {
+                continue;
+            }
+
+            AddUndirectedEdge(adjacency, resultId, otherMaterial.Value);
+        }
+
+        return ToComponents(adjacency);
+    }
+
+    private static void AddUndirectedEdge(Dictionary<MaterialId, HashSet<MaterialId>> adjacency, MaterialId a, MaterialId b)
+    {
+        if (!adjacency.TryGetValue(a, out HashSet<MaterialId>? setA))
+        {
+            setA = [];
+            adjacency[a] = setA;
+        }
+
+        if (!adjacency.TryGetValue(b, out HashSet<MaterialId>? setB))
+        {
+            setB = [];
+            adjacency[b] = setB;
+        }
+
+        _ = setA.Add(b);
+        _ = setB.Add(a);
+    }
+
+    private static ImmutableArray<ImmutableArray<MaterialId>> ToComponents(Dictionary<MaterialId, HashSet<MaterialId>> adjacency)
+    {
+        if (adjacency.Count is 0)
+        {
+            return ImmutableArray<ImmutableArray<MaterialId>>.Empty;
+        }
+
+        HashSet<MaterialId> visited = [];
+        ImmutableArray<ImmutableArray<MaterialId>>.Builder groups = ImmutableArray.CreateBuilder<ImmutableArray<MaterialId>>();
+
+        foreach (MaterialId start in adjacency.Keys)
+        {
+            if (visited.Contains(start))
+            {
+                continue;
+            }
+
+            List<MaterialId> component = [];
+            Queue<MaterialId> queue = new();
+            queue.Enqueue(start);
+            visited.Add(start);
+
+            while (queue.Count > 0)
+            {
+                MaterialId id = queue.Dequeue();
+                component.Add(id);
+
+                if (!adjacency.TryGetValue(id, out HashSet<MaterialId>? neighbors))
+                {
+                    continue;
+                }
+
+                foreach (MaterialId n in neighbors)
+                {
+                    if (visited.Add(n))
+                    {
+                        queue.Enqueue(n);
+                    }
+                }
+            }
+
+            if (component.Count >= 2)
+            {
+                component.Sort(MaterialIdComparer.Shared);
+                groups.Add(component.ToImmutableArray());
+            }
+        }
+
+        return groups.ToImmutable();
+    }
+}

--- a/src/Snap.Hutao/Snap.Hutao/Service/Inventory/InventoryService.cs
+++ b/src/Snap.Hutao/Snap.Hutao/Service/Inventory/InventoryService.cs
@@ -105,7 +105,18 @@ internal sealed partial class InventoryService : IInventoryService
         {
             static IEnumerable<InventoryItem> ToInventoryItems(ImmutableArray<Item> consumeItems, Guid projectId)
             {
-                return consumeItems.SelectAsArray(static (item, pid) => InventoryItem.From(pid, item.Id, (uint)((int)item.Num - item.LackNum)), projectId);
+                static uint ToSafeCount(Item item)
+                {
+                    long delta = (long)item.Num - item.LackNum;
+                    if (delta <= 0)
+                    {
+                        return 0U;
+                    }
+
+                    return delta >= uint.MaxValue ? uint.MaxValue : (uint)delta;
+                }
+
+                return consumeItems.SelectAsArray(static (item, pid) => InventoryItem.From(pid, item.Id, ToSafeCount(item)), projectId);
             }
 
             if (syncToAllProjects)

--- a/src/Snap.Hutao/Snap.Hutao/Service/Inventory/InventoryService.cs
+++ b/src/Snap.Hutao/Snap.Hutao/Service/Inventory/InventoryService.cs
@@ -23,6 +23,7 @@ internal sealed partial class InventoryService : IInventoryService
     private readonly PromotionDeltaFactory promotionDeltaFactory;
     private readonly IServiceScopeFactory serviceScopeFactory;
     private readonly IInventoryRepository inventoryRepository;
+    private readonly ICultivationRepository cultivationRepository;
     private readonly IUserService userService;
     private readonly IMessenger messenger;
 
@@ -55,7 +56,7 @@ internal sealed partial class InventoryService : IInventoryService
         {
             case RefreshOptionKind.WebCalculator:
                 ArgumentNullException.ThrowIfNull(refreshOptions.MetadataContext);
-                return RefreshInventoryByCalculatorAsync(refreshOptions.MetadataContext, refreshOptions.Project);
+                return RefreshInventoryByCalculatorAsync(refreshOptions);
             case RefreshOptionKind.EmbeddedYae:
                 ArgumentNullException.ThrowIfNull(refreshOptions.YaeService);
                 ArgumentNullException.ThrowIfNull(refreshOptions.ViewModelSupportLaunchExecution);
@@ -71,8 +72,12 @@ internal sealed partial class InventoryService : IInventoryService
         inventoryRepository.RemoveInventoryItemRangeByProjectId(projectId);
     }
 
-    private async ValueTask RefreshInventoryByCalculatorAsync(ICultivationMetadataContext context, CultivateProject project)
+    private async ValueTask RefreshInventoryByCalculatorAsync(RefreshOptions options)
     {
+        ICultivationMetadataContext context = options.MetadataContext!;
+        CultivateProject project = options.Project;
+        bool syncToAllProjects = options.SyncCalculatorInventoryToAllProjects;
+
         if (await userService.GetCurrentUserAndUidAsync().ConfigureAwait(false) is not { } userAndUid)
         {
             messenger.Send(InfoBarMessage.Warning(SH.MustSelectUserAndUid));
@@ -98,8 +103,25 @@ internal sealed partial class InventoryService : IInventoryService
 
         if (batchConsumption is { OverallConsume: { IsDefault: false } items })
         {
-            inventoryRepository.RemoveInventoryItemRangeByProjectId(project.InnerId);
-            inventoryRepository.AddInventoryItemRangeByProjectId(items.SelectAsArray(static (item, project) => InventoryItem.From(project.InnerId, item.Id, (uint)((int)item.Num - item.LackNum)), project));
+            static IEnumerable<InventoryItem> ToInventoryItems(ImmutableArray<Item> consumeItems, Guid projectId)
+            {
+                return consumeItems.SelectAsArray(static (item, pid) => InventoryItem.From(pid, item.Id, (uint)((int)item.Num - item.LackNum)), projectId);
+            }
+
+            if (syncToAllProjects)
+            {
+                ImmutableArray<Guid> projectIds = cultivationRepository.GetCultivateProjectInnerIds();
+                foreach (Guid projectId in projectIds.AsSpan())
+                {
+                    inventoryRepository.RemoveInventoryItemRangeByProjectId(projectId);
+                    inventoryRepository.AddInventoryItemRangeByProjectId(ToInventoryItems(items, projectId));
+                }
+            }
+            else
+            {
+                inventoryRepository.RemoveInventoryItemRangeByProjectId(project.InnerId);
+                inventoryRepository.AddInventoryItemRangeByProjectId(ToInventoryItems(items, project.InnerId));
+            }
         }
     }
 

--- a/src/Snap.Hutao/Snap.Hutao/Service/Inventory/RefreshOptions.cs
+++ b/src/Snap.Hutao/Snap.Hutao/Service/Inventory/RefreshOptions.cs
@@ -24,7 +24,12 @@ internal sealed class RefreshOptions
 
     public required IViewModelSupportLaunchExecution? ViewModelSupportLaunchExecution { get; init; }
 
-    public static RefreshOptions CreateForWebCalculator(CultivateProject project, ICultivationMetadataContext context)
+    /// <summary>
+    /// 通过养成计算器同步背包时，是否将结果写入所有养成计划（否则仅当前计划）。
+    /// </summary>
+    public bool SyncCalculatorInventoryToAllProjects { get; init; }
+
+    public static RefreshOptions CreateForWebCalculator(CultivateProject project, ICultivationMetadataContext context, bool syncCalculatorInventoryToAllProjects = false)
     {
         return new()
         {
@@ -33,6 +38,7 @@ internal sealed class RefreshOptions
             MetadataContext = context,
             YaeService = default,
             ViewModelSupportLaunchExecution = default,
+            SyncCalculatorInventoryToAllProjects = syncCalculatorInventoryToAllProjects,
         };
     }
 

--- a/src/Snap.Hutao/Snap.Hutao/Service/Metadata/CombineResultMaterialIdMapFactory.cs
+++ b/src/Snap.Hutao/Snap.Hutao/Service/Metadata/CombineResultMaterialIdMapFactory.cs
@@ -1,0 +1,64 @@
+// Copyright (c) DGP Studio. All rights reserved.
+// Licensed under the MIT license.
+
+using Snap.Hutao.Model.Intrinsic;
+using Snap.Hutao.Model.Metadata;
+using Snap.Hutao.Model.Primitive;
+using System.Collections.Immutable;
+
+namespace Snap.Hutao.Service.Metadata;
+
+/// <summary>
+/// Combine 元数据中多条配方可共享同一产物 Id（例如元素断片既有 3×碎屑合成，也有用其他元素石与尘的转化）。
+/// 构建 MaterialId→Combine 映射时必须优先保留「单材料×3→产物×1」的合成台主链，否则后项覆盖前项会导致养成统计无法向下展开原料。
+/// </summary>
+internal static class CombineResultMaterialIdMapFactory
+{
+    public static ImmutableDictionary<MaterialId, Combine> ToImmutableDictionary(ImmutableArray<Combine> combines)
+    {
+        Dictionary<MaterialId, Combine> map = [];
+
+        foreach (Combine current in combines)
+        {
+            MaterialId key = current.Result.Id;
+            if (!map.TryGetValue(key, out Combine? existing))
+            {
+                map[key] = current;
+                continue;
+            }
+
+            if (ComparePreference(current, existing) > 0)
+            {
+                map[key] = current;
+            }
+        }
+
+        return map.ToImmutableDictionary();
+    }
+
+    /// <summary>正数表示 <paramref name="incoming"/> 应取代已有项。</summary>
+    private static int ComparePreference(Combine incoming, Combine existing)
+    {
+        return Score(incoming).CompareTo(Score(existing));
+    }
+
+    private static int Score(Combine c)
+    {
+        if (c.Materials.Length is 1 && c.Materials[0].Count is 3 && c.Result.Count is 1)
+        {
+            return c.RecipeType switch
+            {
+                RecipeType.RECIPE_TYPE_COMBINE => 300,
+                RecipeType.RECIPE_TYPE_CONVERT => 200,
+                _ => 150,
+            };
+        }
+
+        if (c.RecipeType is RecipeType.RECIPE_TYPE_COMBINE)
+        {
+            return 100;
+        }
+
+        return 0;
+    }
+}

--- a/src/Snap.Hutao/Snap.Hutao/Service/Metadata/ContextAbstraction/IMetadataWeeklyBossMaterialInterchangeGroupsSource.cs
+++ b/src/Snap.Hutao/Snap.Hutao/Service/Metadata/ContextAbstraction/IMetadataWeeklyBossMaterialInterchangeGroupsSource.cs
@@ -1,0 +1,15 @@
+// Copyright (c) DGP Studio. All rights reserved.
+// Licensed under the MIT license.
+
+using Snap.Hutao.Model.Primitive;
+using System.Collections.Immutable;
+
+namespace Snap.Hutao.Service.Metadata.ContextAbstraction;
+
+/// <summary>
+/// 周本 Boss 掉落材料「异梦转化」互通组（由 Combine 元数据解析）。
+/// </summary>
+internal interface IMetadataWeeklyBossMaterialInterchangeGroupsSource : IMetadataContext
+{
+    ImmutableArray<ImmutableArray<MaterialId>> WeeklyBossMaterialInterchangeGroups { get; set; }
+}

--- a/src/Snap.Hutao/Snap.Hutao/Service/Metadata/ContextAbstraction/MetadataServiceContextExtension.cs
+++ b/src/Snap.Hutao/Snap.Hutao/Service/Metadata/ContextAbstraction/MetadataServiceContextExtension.cs
@@ -211,6 +211,11 @@ internal static class MetadataServiceContextExtension
                 {
                     dictionaryResultMaterialIdCombineSource.ResultMaterialIdCombineMap = await metadataService.GetResultMaterialIdToCombineMapAsync(token).ConfigureAwait(false);
                 }
+
+                if (context is IMetadataWeeklyBossMaterialInterchangeGroupsSource weeklyBossInterchange)
+                {
+                    weeklyBossInterchange.WeeklyBossMaterialInterchangeGroups = await metadataService.GetWeeklyBossMaterialInterchangeGroupsAsync(token).ConfigureAwait(false);
+                }
             }
 
             if (context is IMetadataSupportInitialization supportInitialization)

--- a/src/Snap.Hutao/Snap.Hutao/Service/Metadata/MetadataServiceImmutableDictionaryExtension.cs
+++ b/src/Snap.Hutao/Snap.Hutao/Service/Metadata/MetadataServiceImmutableDictionaryExtension.cs
@@ -216,12 +216,17 @@ internal static class MetadataServiceImmutableDictionaryExtension
                 token);
         }
 
-        public ValueTask<ImmutableDictionary<MaterialId, Combine>> GetResultMaterialIdToCombineMapAsync(CancellationToken token = default)
+        public async ValueTask<ImmutableDictionary<MaterialId, Combine>> GetResultMaterialIdToCombineMapAsync(CancellationToken token = default)
         {
-            return metadataService.FromCacheAsDictionaryAsync<MaterialId, Combine>(
-                MetadataFileStrategies.Combine,
-                c => c.Result.Id,
-                token);
+            string cacheKey = $"{nameof(MetadataService)}.Cache.{MetadataFileStrategies.Combine.Name}.Map.{nameof(MaterialId)}.{nameof(Combine)}.PreferThreeToOne";
+            ImmutableDictionary<MaterialId, Combine>? result = await metadataService.MemoryCache.GetOrCreateAsync(cacheKey, async entry =>
+            {
+                ImmutableArray<Combine> array = await metadataService.FromCacheOrFileAsync<Combine>(MetadataFileStrategies.Combine, token).ConfigureAwait(false);
+                return CombineResultMaterialIdMapFactory.ToImmutableDictionary(array);
+            }).ConfigureAwait(false);
+
+            ArgumentNullException.ThrowIfNull(result);
+            return result;
         }
 
         private ValueTask<ImmutableDictionary<TKey, TValue>> FromCacheAsDictionaryAsync<TKey, TValue>(MetadataFileStrategy strategy, CancellationToken token)

--- a/src/Snap.Hutao/Snap.Hutao/Service/Metadata/MetadataServiceImmutableDictionaryExtension.cs
+++ b/src/Snap.Hutao/Snap.Hutao/Service/Metadata/MetadataServiceImmutableDictionaryExtension.cs
@@ -13,6 +13,7 @@ using Snap.Hutao.Model.Metadata.Reliquary;
 using Snap.Hutao.Model.Metadata.Tower;
 using Snap.Hutao.Model.Metadata.Weapon;
 using Snap.Hutao.Model.Primitive;
+using Snap.Hutao.Service.Cultivation;
 using System.Collections.Immutable;
 
 namespace Snap.Hutao.Service.Metadata;
@@ -227,6 +228,18 @@ internal static class MetadataServiceImmutableDictionaryExtension
 
             ArgumentNullException.ThrowIfNull(result);
             return result;
+        }
+
+        public async ValueTask<ImmutableArray<ImmutableArray<MaterialId>>> GetWeeklyBossMaterialInterchangeGroupsAsync(CancellationToken token = default)
+        {
+            string cacheKey = $"{nameof(MetadataService)}.Cache.{MetadataFileStrategies.Combine.Name}.WeeklyBossMaterialInterchangeGroups";
+            ImmutableArray<ImmutableArray<MaterialId>>? result = await metadataService.MemoryCache.GetOrCreateAsync(cacheKey, async entry =>
+            {
+                ImmutableArray<Combine> array = await metadataService.FromCacheOrFileAsync<Combine>(MetadataFileStrategies.Combine, token).ConfigureAwait(false);
+                return WeeklyBossMaterialInterchangeGroupsBuilder.Build(array);
+            }).ConfigureAwait(false);
+
+            return result ?? ImmutableArray<ImmutableArray<MaterialId>>.Empty;
         }
 
         private ValueTask<ImmutableDictionary<TKey, TValue>> FromCacheAsDictionaryAsync<TKey, TValue>(MetadataFileStrategy strategy, CancellationToken token)

--- a/src/Snap.Hutao/Snap.Hutao/UI/Xaml/View/Dialog/CultivatePromotionDeltaBatchDialog.xaml
+++ b/src/Snap.Hutao/Snap.Hutao/UI/Xaml/View/Dialog/CultivatePromotionDeltaBatchDialog.xaml
@@ -20,7 +20,9 @@
         <x:Double x:Key="SettingsCardWrapThreshold">0</x:Double>
         <x:Double x:Key="SettingsCardWrapNoIconThreshold">0</x:Double>
     </ContentDialog.Resources>
-    <StackPanel Spacing="{StaticResource SettingsCardSpacing}">
+    <!-- ScrollViewer：随 ContentDialog 主题高度上限自适应；内容过高时纵向滚动，避免裁切或写死 MaxHeight -->
+    <ScrollViewer HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Auto">
+        <StackPanel Spacing="{StaticResource SettingsCardSpacing}">
         <cwc:SettingsCard Header="{shuxm:ResourceString Name=ViewDialogCultivateBatchAvatarLevelTarget}">
             <NumberBox
                 MinWidth="{StaticResource NumberBoxMinWidth}"
@@ -82,5 +84,14 @@
             Margin="0,13,0,0"
             Content="{shuxm:ResourceString Name=ViewDialogCultivateBatchClearAvatarAndWeaponEntries}"
             IsChecked="{x:Bind ClearAvatarAndWeaponEntriesBeforeSync, Mode=TwoWay}"/>
-    </StackPanel>
+        <CheckBox
+            Margin="0,6,0,0"
+            Content="{shuxm:ResourceString Name=ViewPageCultivationRefreshInventory}"
+            IsChecked="{x:Bind SyncInventoryItems, Mode=TwoWay}"/>
+        <CheckBox
+            Margin="0,6,0,0"
+            Content="{shuxm:ResourceString Name=ViewAvatarPropertySyncDataButtonLabel}"
+            IsChecked="{x:Bind SyncCharacterInfo, Mode=TwoWay}"/>
+        </StackPanel>
+    </ScrollViewer>
 </ContentDialog>

--- a/src/Snap.Hutao/Snap.Hutao/UI/Xaml/View/Dialog/CultivatePromotionDeltaBatchDialog.xaml
+++ b/src/Snap.Hutao/Snap.Hutao/UI/Xaml/View/Dialog/CultivatePromotionDeltaBatchDialog.xaml
@@ -77,5 +77,10 @@
             <RadioButton Content="{shuxm:ResourceString Name=ViewDialogCultivationConsumptionSaveStrategyOverwriteExisting}"/>
             <RadioButton Content="{shuxm:ResourceString Name=ViewDialogCultivationConsumptionSaveStrategyCreateNewEntry}"/>
         </RadioButtons>
+
+        <CheckBox
+            Margin="0,13,0,0"
+            Content="{shuxm:ResourceString Name=ViewDialogCultivateBatchClearAvatarAndWeaponEntries}"
+            IsChecked="{x:Bind ClearAvatarAndWeaponEntriesBeforeSync, Mode=TwoWay}"/>
     </StackPanel>
 </ContentDialog>

--- a/src/Snap.Hutao/Snap.Hutao/UI/Xaml/View/Dialog/CultivatePromotionDeltaBatchDialog.xaml.cs
+++ b/src/Snap.Hutao/Snap.Hutao/UI/Xaml/View/Dialog/CultivatePromotionDeltaBatchDialog.xaml.cs
@@ -10,6 +10,7 @@ using Snap.Hutao.Web.Hoyolab.Takumi.Event.Calculate;
 namespace Snap.Hutao.UI.Xaml.View.Dialog;
 
 [DependencyProperty<AvatarPromotionDelta>("PromotionDelta", NotNull = true, CreateDefaultValueCallbackName = nameof(CreatePromotionDeltaDefaultValue))]
+[DependencyProperty<bool>("ClearAvatarAndWeaponEntriesBeforeSync", DefaultValue = false, NotNull = true)]
 internal sealed partial class CultivatePromotionDeltaBatchDialog : ContentDialog
 {
     private readonly IContentDialogFactory contentDialogFactory;
@@ -45,7 +46,7 @@ internal sealed partial class CultivatePromotionDeltaBatchDialog : ContentDialog
             LocalSetting.Set(SettingKeys.CultivationWeapon90LevelTarget, weapon.LevelTarget);
         }
 
-        return new(true, new(PromotionDelta, (ConsumptionSaveStrategyKind)SaveModeSelector.SelectedIndex));
+        return new(true, new CultivatePromotionDeltaOptions(PromotionDelta, (ConsumptionSaveStrategyKind)SaveModeSelector.SelectedIndex, ClearAvatarAndWeaponEntriesBeforeSync));
     }
 
     private static object CreatePromotionDeltaDefaultValue()

--- a/src/Snap.Hutao/Snap.Hutao/UI/Xaml/View/Dialog/CultivatePromotionDeltaBatchDialog.xaml.cs
+++ b/src/Snap.Hutao/Snap.Hutao/UI/Xaml/View/Dialog/CultivatePromotionDeltaBatchDialog.xaml.cs
@@ -4,6 +4,7 @@
 using Microsoft.UI.Xaml.Controls;
 using Snap.Hutao.Core.Setting;
 using Snap.Hutao.Factory.ContentDialog;
+using Snap.Hutao.Model.Cultivation;
 using Snap.Hutao.Service.Cultivation.Consumption;
 using Snap.Hutao.Web.Hoyolab.Takumi.Event.Calculate;
 
@@ -15,8 +16,17 @@ internal sealed partial class CultivatePromotionDeltaBatchDialog : ContentDialog
 {
     private readonly IContentDialogFactory contentDialogFactory;
 
-    [GeneratedConstructor(InitializeComponent = true)]
-    public partial CultivatePromotionDeltaBatchDialog(IServiceProvider serviceProvider);
+    public CultivatePromotionDeltaBatchDialog(IServiceProvider serviceProvider, CultivateProjectAvatarPropertyBatchPreferences? initialPreferences = null)
+    {
+        InitializeComponent();
+
+        contentDialogFactory = serviceProvider.GetRequiredService<IContentDialogFactory>();
+
+        if (initialPreferences is not null)
+        {
+            ApplyInitialPreferences(initialPreferences);
+        }
+    }
 
     public async ValueTask<ValueResult<bool, CultivatePromotionDeltaOptions>> GetPromotionDeltaBaselineAsync()
     {
@@ -47,6 +57,26 @@ internal sealed partial class CultivatePromotionDeltaBatchDialog : ContentDialog
         }
 
         return new(true, new CultivatePromotionDeltaOptions(PromotionDelta, (ConsumptionSaveStrategyKind)SaveModeSelector.SelectedIndex, ClearAvatarAndWeaponEntriesBeforeSync));
+    }
+
+    private void ApplyInitialPreferences(CultivateProjectAvatarPropertyBatchPreferences p)
+    {
+        PromotionDelta.AvatarLevelTarget = p.AvatarLevelTarget;
+
+        if (PromotionDelta.SkillList is [{ } a, { } e, { } q, ..])
+        {
+            a.LevelTarget = p.SkillATarget;
+            e.LevelTarget = p.SkillETarget;
+            q.LevelTarget = p.SkillQTarget;
+        }
+
+        if (PromotionDelta.Weapon is { } w)
+        {
+            w.LevelTarget = p.WeaponLevelTarget;
+        }
+
+        SaveModeSelector.SelectedIndex = int.Clamp(p.ConsumptionSaveStrategyIndex, 0, 2);
+        ClearAvatarAndWeaponEntriesBeforeSync = p.ClearAvatarAndWeaponEntriesBeforeSync;
     }
 
     private static object CreatePromotionDeltaDefaultValue()

--- a/src/Snap.Hutao/Snap.Hutao/UI/Xaml/View/Dialog/CultivatePromotionDeltaBatchDialog.xaml.cs
+++ b/src/Snap.Hutao/Snap.Hutao/UI/Xaml/View/Dialog/CultivatePromotionDeltaBatchDialog.xaml.cs
@@ -12,6 +12,8 @@ namespace Snap.Hutao.UI.Xaml.View.Dialog;
 
 [DependencyProperty<AvatarPromotionDelta>("PromotionDelta", NotNull = true, CreateDefaultValueCallbackName = nameof(CreatePromotionDeltaDefaultValue))]
 [DependencyProperty<bool>("ClearAvatarAndWeaponEntriesBeforeSync", DefaultValue = false, NotNull = true)]
+[DependencyProperty<bool>("SyncInventoryItems", DefaultValue = false, NotNull = true)]
+[DependencyProperty<bool>("SyncCharacterInfo", DefaultValue = false, NotNull = true)]
 internal sealed partial class CultivatePromotionDeltaBatchDialog : ContentDialog
 {
     private readonly IContentDialogFactory contentDialogFactory;
@@ -56,7 +58,7 @@ internal sealed partial class CultivatePromotionDeltaBatchDialog : ContentDialog
             LocalSetting.Set(SettingKeys.CultivationWeapon90LevelTarget, weapon.LevelTarget);
         }
 
-        return new(true, new CultivatePromotionDeltaOptions(PromotionDelta, (ConsumptionSaveStrategyKind)SaveModeSelector.SelectedIndex, ClearAvatarAndWeaponEntriesBeforeSync));
+        return new(true, new CultivatePromotionDeltaOptions(PromotionDelta, (ConsumptionSaveStrategyKind)SaveModeSelector.SelectedIndex, ClearAvatarAndWeaponEntriesBeforeSync, SyncInventoryItems, SyncCharacterInfo));
     }
 
     private void ApplyInitialPreferences(CultivateProjectAvatarPropertyBatchPreferences p)
@@ -77,6 +79,8 @@ internal sealed partial class CultivatePromotionDeltaBatchDialog : ContentDialog
 
         SaveModeSelector.SelectedIndex = int.Clamp(p.ConsumptionSaveStrategyIndex, 0, 2);
         ClearAvatarAndWeaponEntriesBeforeSync = p.ClearAvatarAndWeaponEntriesBeforeSync;
+        SyncInventoryItems = p.SyncInventoryItems;
+        SyncCharacterInfo = p.SyncCharacterInfo;
     }
 
     private static object CreatePromotionDeltaDefaultValue()

--- a/src/Snap.Hutao/Snap.Hutao/UI/Xaml/View/Dialog/CultivatePromotionDeltaOptions.cs
+++ b/src/Snap.Hutao/Snap.Hutao/UI/Xaml/View/Dialog/CultivatePromotionDeltaOptions.cs
@@ -8,7 +8,7 @@ namespace Snap.Hutao.UI.Xaml.View.Dialog;
 
 internal sealed class CultivatePromotionDeltaOptions
 {
-    public CultivatePromotionDeltaOptions(AvatarPromotionDelta delta, ConsumptionSaveStrategyKind strategy)
+    public CultivatePromotionDeltaOptions(AvatarPromotionDelta delta, ConsumptionSaveStrategyKind strategy, bool clearAvatarAndWeaponEntriesBeforeSync = false)
     {
         delta.AvatarLevelTarget = delta.AvatarLevelTarget switch
         {
@@ -19,9 +19,15 @@ internal sealed class CultivatePromotionDeltaOptions
 
         Delta = delta;
         Strategy = strategy;
+        ClearAvatarAndWeaponEntriesBeforeSync = clearAvatarAndWeaponEntriesBeforeSync;
     }
 
     public AvatarPromotionDelta Delta { get; }
 
     public ConsumptionSaveStrategyKind Strategy { get; }
+
+    /// <summary>
+    /// 批量同步前是否清空当前计划中已有的角色与武器养成条目（不含家具等其它类型）。
+    /// </summary>
+    public bool ClearAvatarAndWeaponEntriesBeforeSync { get; }
 }

--- a/src/Snap.Hutao/Snap.Hutao/UI/Xaml/View/Dialog/CultivatePromotionDeltaOptions.cs
+++ b/src/Snap.Hutao/Snap.Hutao/UI/Xaml/View/Dialog/CultivatePromotionDeltaOptions.cs
@@ -8,7 +8,7 @@ namespace Snap.Hutao.UI.Xaml.View.Dialog;
 
 internal sealed class CultivatePromotionDeltaOptions
 {
-    public CultivatePromotionDeltaOptions(AvatarPromotionDelta delta, ConsumptionSaveStrategyKind strategy, bool clearAvatarAndWeaponEntriesBeforeSync = false)
+    public CultivatePromotionDeltaOptions(AvatarPromotionDelta delta, ConsumptionSaveStrategyKind strategy, bool clearAvatarAndWeaponEntriesBeforeSync = false, bool syncInventoryItems = false, bool syncCharacterInfo = false)
     {
         delta.AvatarLevelTarget = delta.AvatarLevelTarget switch
         {
@@ -20,6 +20,8 @@ internal sealed class CultivatePromotionDeltaOptions
         Delta = delta;
         Strategy = strategy;
         ClearAvatarAndWeaponEntriesBeforeSync = clearAvatarAndWeaponEntriesBeforeSync;
+        SyncInventoryItems = syncInventoryItems;
+        SyncCharacterInfo = syncCharacterInfo;
     }
 
     public AvatarPromotionDelta Delta { get; }
@@ -30,4 +32,8 @@ internal sealed class CultivatePromotionDeltaOptions
     /// 批量同步前是否清空当前计划中已有的角色与武器养成条目（不含家具等其它类型）。
     /// </summary>
     public bool ClearAvatarAndWeaponEntriesBeforeSync { get; }
+
+    public bool SyncInventoryItems { get; }
+
+    public bool SyncCharacterInfo { get; }
 }

--- a/src/Snap.Hutao/Snap.Hutao/UI/Xaml/View/Page/CultivationPage.xaml
+++ b/src/Snap.Hutao/Snap.Hutao/UI/Xaml/View/Page/CultivationPage.xaml
@@ -588,6 +588,12 @@
                                     IsEnabled="{Binding MergeUpgradeMaterials}"
                                     Label="{shuxm:ResourceString Name=ViewPageCultivationTalentSynthCritTenPercentLabel}"
                                     Visibility="{Binding ElementName=MaterialListPivot, Path=SelectedItem.Tag, Converter={StaticResource MaterialListSelectedItemIsStatisticsViewConverter}}"/>
+                                <AppBarToggleButton
+                                    Command="{Binding RefreshStatisticsItemsCommand}"
+                                    Icon="{shuxm:FontIcon Glyph=&#xE8FD;}"
+                                    IsChecked="{Binding WeeklyBossMaterialInterchange, Mode=TwoWay}"
+                                    Label="{shuxm:ResourceString Name=ViewPageCultivationWeeklyBossMaterialInterchangeLabel}"
+                                    Visibility="{Binding ElementName=MaterialListPivot, Path=SelectedItem.Tag, Converter={StaticResource MaterialListSelectedItemIsStatisticsViewConverter}}"/>
                                 <AppBarButton Icon="{shuxm:FontIcon Glyph=&#xE946;}" Label="{shuxm:ResourceString Name=ViewPageCultivationMaterialListResinStatisticsLabel}">
                                     <AppBarButton.Flyout>
                                         <Flyout FlyoutPresenterStyle="{ThemeResource FlyoutPresenterPadding0Style}" Placement="BottomEdgeAlignedRight">

--- a/src/Snap.Hutao/Snap.Hutao/UI/Xaml/View/Page/CultivationPage.xaml
+++ b/src/Snap.Hutao/Snap.Hutao/UI/Xaml/View/Page/CultivationPage.xaml
@@ -467,6 +467,10 @@
                         CommandParameter="{Binding Projects.CurrentItem, Mode=OneWay}"
                         Icon="{shuxm:FontIcon Glyph=&#xE894;}"
                         Label="{shuxm:ResourceString Name=ViewPageCultivationClearInventory}"/>
+                    <AppBarButton
+                        Command="{Binding SyncAllAvatarsAndWeaponsCommand}"
+                        Icon="{shuxm:FontIcon Glyph=&#xE72C;}"
+                        Label="{shuxm:ResourceString Name=ViewPageCultivationSyncAllAvatarsAndWeapons}"/>
                     <AppBarButton Icon="{shuxm:FontIcon Glyph=&#xE895;}" Label="{shuxm:ResourceString Name=ViewPageCultivationRefreshInventory}">
                         <AppBarButton.Flyout>
                             <MenuFlyout Placement="BottomEdgeAlignedRight">

--- a/src/Snap.Hutao/Snap.Hutao/UI/Xaml/View/Page/CultivationPage.xaml
+++ b/src/Snap.Hutao/Snap.Hutao/UI/Xaml/View/Page/CultivationPage.xaml
@@ -471,7 +471,9 @@
                         Command="{Binding SyncAllAvatarsAndWeaponsCommand}"
                         Icon="{shuxm:FontIcon Glyph=&#xE72C;}"
                         Label="{shuxm:ResourceString Name=ViewPageCultivationSyncAllAvatarsAndWeapons}"/>
-                    <AppBarButton Icon="{shuxm:FontIcon Glyph=&#xE895;}" Label="{shuxm:ResourceString Name=ViewPageCultivationRefreshInventory}">
+                    <AppBarButton
+                        Icon="{shuxm:FontIcon Glyph=&#xE895;}"
+                        Label="{shuxm:ResourceString Name=ViewPageCultivationRefreshInventory}">
                         <AppBarButton.Flyout>
                             <MenuFlyout Placement="BottomEdgeAlignedRight">
                                 <MenuFlyoutItem
@@ -485,6 +487,10 @@
                             </MenuFlyout>
                         </AppBarButton.Flyout>
                     </AppBarButton>
+                    <AppBarToggleButton
+                        Icon="{shuxm:FontIcon Glyph=&#xE8B7;}"
+                        IsChecked="{Binding SyncInventoryByCalculatorToAllProjects, Mode=TwoWay}"
+                        Label="{shuxm:ResourceString Name=ViewPageCultivationRefreshInventoryAllPlansShortLabel}"/>
                     <AppBarButton
                         Command="{Binding AddProjectCommand}"
                         Icon="{shuxm:FontIcon Glyph=&#xE710;}"
@@ -733,7 +739,6 @@
                                 </Style>
                             </GridView.ItemContainerStyle>
                         </GridView>
-
                     </Border>
                 </Border>
             </PivotItem>

--- a/src/Snap.Hutao/Snap.Hutao/UI/Xaml/View/Page/CultivationPage.xaml
+++ b/src/Snap.Hutao/Snap.Hutao/UI/Xaml/View/Page/CultivationPage.xaml
@@ -256,11 +256,40 @@
                                 VerticalAlignment="Center"
                                 Text="{Binding Inner.Name}"
                                 TextTrimming="CharacterEllipsis"/>
-                            <TextBlock
+                            <StackPanel
                                 Grid.Column="1"
-                                Margin="0,0,0,0"
                                 VerticalAlignment="Center"
-                                Text="{Binding FormattedCount}"/>
+                                Orientation="Horizontal"
+                                Spacing="0">
+                                <TextBlock
+                                    VerticalAlignment="Center"
+                                    Text="{Binding FormattedCount}"
+                                    Visibility="{Binding ShowNonMergeCompactCount, Converter={StaticResource BoolToVisibilityConverter}}"/>
+                                <StackPanel
+                                    Orientation="Horizontal"
+                                    Spacing="0"
+                                    Visibility="{Binding ShowMergeSpacedWithoutParen, Converter={StaticResource BoolToVisibilityConverter}}">
+                                    <TextBlock VerticalAlignment="Center" Text="{Binding DisplayCurrent, Mode=OneWay}"/>
+                                    <TextBlock VerticalAlignment="Center" Text="{Binding SlashCountSuffix, Mode=OneWay}"/>
+                                </StackPanel>
+                                <StackPanel
+                                    Orientation="Horizontal"
+                                    Spacing="0"
+                                    Visibility="{Binding ShowMergeInventoryParen, Converter={StaticResource BoolToVisibilityConverter}}">
+                                    <TextBlock VerticalAlignment="Center" Text="{Binding DisplayCurrent, Mode=OneWay}"/>
+                                    <TextBlock
+                                        VerticalAlignment="Center"
+                                        Foreground="{ThemeResource AccentTextFillColorPrimaryBrush}"
+                                        Text="{Binding RawInventoryParenthetical, Mode=OneWay}"
+                                        Visibility="{Binding MergeInventoryParenUseBlue, Converter={StaticResource BoolToVisibilityConverter}}"/>
+                                    <TextBlock
+                                        VerticalAlignment="Center"
+                                        Foreground="{ThemeResource SystemFillColorCriticalBrush}"
+                                        Text="{Binding RawInventoryParenthetical, Mode=OneWay}"
+                                        Visibility="{Binding MergeInventoryParenUseRed, Converter={StaticResource BoolToVisibilityConverter}}"/>
+                                    <TextBlock VerticalAlignment="Center" Text="{Binding SlashCountSuffix, Mode=OneWay}"/>
+                                </StackPanel>
+                            </StackPanel>
                         </Grid>
                     </shuxcc:HorizontalCard.Right>
                 </shuxcc:HorizontalCard>

--- a/src/Snap.Hutao/Snap.Hutao/UI/Xaml/View/Page/CultivationPage.xaml
+++ b/src/Snap.Hutao/Snap.Hutao/UI/Xaml/View/Page/CultivationPage.xaml
@@ -238,12 +238,52 @@
                             <ScrollViewer MaxHeight="320" MinWidth="220" Padding="12,10">
                                 <ItemsControl ItemsSource="{Binding StatisticsConsumerMenuLines, Mode=OneWay}">
                                     <ItemsControl.ItemTemplate>
-                                        <DataTemplate x:DataType="x:String">
-                                            <TextBlock
-                                                Margin="0,3"
-                                                Style="{ThemeResource BodyTextBlockStyle}"
-                                                Text="{x:Bind Mode=OneWay}"
-                                                TextWrapping="WrapWholeWords"/>
+                                        <DataTemplate x:DataType="shvcu:StatisticsConsumerMenuLine">
+                                            <Grid Margin="0,3">
+                                                <TextBlock
+                                                    Style="{ThemeResource BodyTextBlockStyle}"
+                                                    Text="{x:Bind PlainMessage, Mode=OneWay}"
+                                                    TextWrapping="WrapWholeWords"
+                                                    Visibility="{x:Bind IsPlainMessage, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}"/>
+                                                <StackPanel
+                                                    Orientation="Horizontal"
+                                                    Spacing="4"
+                                                    VerticalAlignment="Center"
+                                                    Visibility="{x:Bind ShowRichRow, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}">
+                                                    <shuxc:ItemIcon
+                                                        Width="28"
+                                                        Height="28"
+                                                        Icon="{x:Bind LeadingIcon, Mode=OneWay}"
+                                                        Quality="{x:Bind LeadingQuality, Mode=OneWay}"/>
+                                                    <TextBlock
+                                                        VerticalAlignment="Center"
+                                                        Style="{ThemeResource BodyTextBlockStyle}"
+                                                        Text="{x:Bind FirstName, Mode=OneWay}"/>
+                                                    <StackPanel
+                                                        Orientation="Horizontal"
+                                                        Spacing="4"
+                                                        VerticalAlignment="Center"
+                                                        Visibility="{x:Bind HasSecondIcon, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}">
+                                                        <TextBlock
+                                                            VerticalAlignment="Center"
+                                                            Style="{ThemeResource BodyTextBlockStyle}"
+                                                            Text="{x:Bind BetweenSeparator, Mode=OneWay}"/>
+                                                        <shuxc:ItemIcon
+                                                            Width="28"
+                                                            Height="28"
+                                                            Icon="{x:Bind SecondIcon, Mode=OneWay}"
+                                                            Quality="{x:Bind SecondQuality, Mode=OneWay}"/>
+                                                        <TextBlock
+                                                            VerticalAlignment="Center"
+                                                            Style="{ThemeResource BodyTextBlockStyle}"
+                                                            Text="{x:Bind SecondName, Mode=OneWay}"/>
+                                                    </StackPanel>
+                                                    <TextBlock
+                                                        VerticalAlignment="Center"
+                                                        Style="{ThemeResource BodyTextBlockStyle}"
+                                                        Text="{x:Bind CountSuffix, Mode=OneWay}"/>
+                                                </StackPanel>
+                                            </Grid>
                                         </DataTemplate>
                                     </ItemsControl.ItemTemplate>
                                 </ItemsControl>

--- a/src/Snap.Hutao/Snap.Hutao/UI/Xaml/View/Page/CultivationPage.xaml
+++ b/src/Snap.Hutao/Snap.Hutao/UI/Xaml/View/Page/CultivationPage.xaml
@@ -198,6 +198,11 @@
                                     Opacity="0.7"
                                     Style="{StaticResource CaptionTextBlockStyle}"
                                     Text="{Binding Description}"/>
+                                <TextBlock
+                                    Opacity="0.7"
+                                    Style="{StaticResource CaptionTextBlockStyle}"
+                                    Text="{Binding RelatedAvatarLine}"
+                                    Visibility="{Binding RelatedAvatarLine, Converter={StaticResource EmptyObjectToVisibilityConverter}}"/>
                             </StackPanel>
 
                             <StackPanel Grid.Column="2" Orientation="Horizontal">

--- a/src/Snap.Hutao/Snap.Hutao/UI/Xaml/View/Page/CultivationPage.xaml
+++ b/src/Snap.Hutao/Snap.Hutao/UI/Xaml/View/Page/CultivationPage.xaml
@@ -276,18 +276,18 @@
                                     Orientation="Horizontal"
                                     Spacing="0"
                                     Visibility="{Binding ShowMergeInventoryParen, Converter={StaticResource BoolToVisibilityConverter}}">
-                                    <TextBlock VerticalAlignment="Center" Text="{Binding DisplayCurrent, Mode=OneWay}"/>
-                                    <TextBlock
-                                        VerticalAlignment="Center"
-                                        Foreground="{ThemeResource AccentTextFillColorPrimaryBrush}"
-                                        Text="{Binding RawInventoryParenthetical, Mode=OneWay}"
-                                        Visibility="{Binding MergeInventoryParenUseBlue, Converter={StaticResource BoolToVisibilityConverter}}"/>
                                     <TextBlock
                                         VerticalAlignment="Center"
                                         Foreground="{ThemeResource SystemFillColorCriticalBrush}"
-                                        Text="{Binding RawInventoryParenthetical, Mode=OneWay}"
-                                        Visibility="{Binding MergeInventoryParenUseRed, Converter={StaticResource BoolToVisibilityConverter}}"/>
-                                    <TextBlock VerticalAlignment="Center" Text="{Binding SlashCountSuffix, Mode=OneWay}"/>
+                                        Text="{Binding DisplayCurrent, Mode=OneWay}"
+                                        Visibility="{Binding MergeDisplayLeadUseRed, Converter={StaticResource BoolToVisibilityConverter}}"/>
+                                    <TextBlock
+                                        VerticalAlignment="Center"
+                                        Foreground="{ThemeResource SystemFillColorSuccessBrush}"
+                                        Text="{Binding DisplayCurrent, Mode=OneWay}"
+                                        Visibility="{Binding MergeDisplayLeadUseGreen, Converter={StaticResource BoolToVisibilityConverter}}"/>
+                                    <TextBlock VerticalAlignment="Center" Text="{Binding RawInventoryParenthetical, Mode=OneWay}"/>
+                                    <TextBlock VerticalAlignment="Center" Text="{Binding SlashCountSuffixForParen, Mode=OneWay}"/>
                                 </StackPanel>
                             </StackPanel>
                         </Grid>

--- a/src/Snap.Hutao/Snap.Hutao/UI/Xaml/View/Page/CultivationPage.xaml
+++ b/src/Snap.Hutao/Snap.Hutao/UI/Xaml/View/Page/CultivationPage.xaml
@@ -232,65 +232,69 @@
             </DataTemplate>
 
             <DataTemplate x:Key="StatisticsItemTemplate" x:DataType="shvcu:StatisticsCultivateItem">
-                <Border Background="Transparent" IsRightTapEnabled="True">
-                    <Border.ContextFlyout>
-                        <Flyout FlyoutPresenterStyle="{ThemeResource FlyoutPresenterPadding0Style}">
-                            <ScrollViewer MaxHeight="320" MinWidth="220" Padding="12,10">
-                                <ItemsControl ItemsSource="{Binding StatisticsConsumerMenuLines, Mode=OneWay}">
-                                    <ItemsControl.ItemTemplate>
-                                        <DataTemplate x:DataType="shvcu:StatisticsConsumerMenuLine">
-                                            <Grid Margin="0,3">
-                                                <TextBlock
-                                                    Style="{ThemeResource BodyTextBlockStyle}"
-                                                    Text="{x:Bind PlainMessage, Mode=OneWay}"
-                                                    TextWrapping="WrapWholeWords"
-                                                    Visibility="{x:Bind IsPlainMessage, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}"/>
-                                                <StackPanel
-                                                    Orientation="Horizontal"
-                                                    Spacing="4"
-                                                    VerticalAlignment="Center"
-                                                    Visibility="{x:Bind ShowRichRow, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}">
-                                                    <shuxc:ItemIcon
-                                                        Width="28"
-                                                        Height="28"
-                                                        Icon="{x:Bind LeadingIcon, Mode=OneWay}"
-                                                        Quality="{x:Bind LeadingQuality, Mode=OneWay}"/>
+                <Border Background="Transparent">
+                    <shuxcc:HorizontalCard
+                        Background="{Binding IsToday, Converter={ThemeResource BoolToStatisticsBrushSelector}}"
+                        IsRightTapEnabled="True"
+                        IsTabStop="True"
+                        UseSystemFocusVisuals="True">
+                        <FrameworkElement.ContextFlyout>
+                            <Flyout FlyoutPresenterStyle="{ThemeResource FlyoutPresenterPadding0Style}">
+                                <ScrollViewer MaxHeight="320" MinWidth="220" Padding="12,10">
+                                    <ItemsControl ItemsSource="{Binding StatisticsConsumerMenuLines, Mode=OneWay}">
+                                        <ItemsControl.ItemTemplate>
+                                            <DataTemplate x:DataType="shvcu:StatisticsConsumerMenuLine">
+                                                <Grid Margin="0,3">
                                                     <TextBlock
-                                                        VerticalAlignment="Center"
                                                         Style="{ThemeResource BodyTextBlockStyle}"
-                                                        Text="{x:Bind FirstName, Mode=OneWay}"/>
+                                                        Text="{x:Bind PlainMessage, Mode=OneWay}"
+                                                        TextWrapping="WrapWholeWords"
+                                                        Visibility="{x:Bind IsPlainMessage, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}"/>
                                                     <StackPanel
                                                         Orientation="Horizontal"
                                                         Spacing="4"
                                                         VerticalAlignment="Center"
-                                                        Visibility="{x:Bind HasSecondIcon, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}">
-                                                        <TextBlock
-                                                            VerticalAlignment="Center"
-                                                            Style="{ThemeResource BodyTextBlockStyle}"
-                                                            Text="{x:Bind BetweenSeparator, Mode=OneWay}"/>
+                                                        Visibility="{x:Bind ShowRichRow, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}">
                                                         <shuxc:ItemIcon
                                                             Width="28"
                                                             Height="28"
-                                                            Icon="{x:Bind SecondIcon, Mode=OneWay}"
-                                                            Quality="{x:Bind SecondQuality, Mode=OneWay}"/>
+                                                            Icon="{x:Bind LeadingIcon, Mode=OneWay}"
+                                                            Quality="{x:Bind LeadingQuality, Mode=OneWay}"/>
                                                         <TextBlock
                                                             VerticalAlignment="Center"
                                                             Style="{ThemeResource BodyTextBlockStyle}"
-                                                            Text="{x:Bind SecondName, Mode=OneWay}"/>
+                                                            Text="{x:Bind FirstName, Mode=OneWay}"/>
+                                                        <StackPanel
+                                                            Orientation="Horizontal"
+                                                            Spacing="4"
+                                                            VerticalAlignment="Center"
+                                                            Visibility="{x:Bind HasSecondIcon, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}">
+                                                            <TextBlock
+                                                                VerticalAlignment="Center"
+                                                                Style="{ThemeResource BodyTextBlockStyle}"
+                                                                Text="{x:Bind BetweenSeparator, Mode=OneWay}"/>
+                                                            <shuxc:ItemIcon
+                                                                Width="28"
+                                                                Height="28"
+                                                                Icon="{x:Bind SecondIcon, Mode=OneWay}"
+                                                                Quality="{x:Bind SecondQuality, Mode=OneWay}"/>
+                                                            <TextBlock
+                                                                VerticalAlignment="Center"
+                                                                Style="{ThemeResource BodyTextBlockStyle}"
+                                                                Text="{x:Bind SecondName, Mode=OneWay}"/>
+                                                        </StackPanel>
+                                                        <TextBlock
+                                                            VerticalAlignment="Center"
+                                                            Style="{ThemeResource BodyTextBlockStyle}"
+                                                            Text="{x:Bind CountSuffix, Mode=OneWay}"/>
                                                     </StackPanel>
-                                                    <TextBlock
-                                                        VerticalAlignment="Center"
-                                                        Style="{ThemeResource BodyTextBlockStyle}"
-                                                        Text="{x:Bind CountSuffix, Mode=OneWay}"/>
-                                                </StackPanel>
-                                            </Grid>
-                                        </DataTemplate>
-                                    </ItemsControl.ItemTemplate>
-                                </ItemsControl>
-                            </ScrollViewer>
-                        </Flyout>
-                    </Border.ContextFlyout>
-                    <shuxcc:HorizontalCard Background="{Binding IsToday, Converter={ThemeResource BoolToStatisticsBrushSelector}}">
+                                                </Grid>
+                                            </DataTemplate>
+                                        </ItemsControl.ItemTemplate>
+                                    </ItemsControl>
+                                </ScrollViewer>
+                            </Flyout>
+                        </FrameworkElement.ContextFlyout>
                     <shuxcc:HorizontalCard.Left>
                         <Grid Grid.Column="0">
                             <shuxc:ItemIcon

--- a/src/Snap.Hutao/Snap.Hutao/UI/Xaml/View/Page/CultivationPage.xaml
+++ b/src/Snap.Hutao/Snap.Hutao/UI/Xaml/View/Page/CultivationPage.xaml
@@ -482,6 +482,19 @@
                                     IsChecked="{Binding IncompleteFirst, Mode=TwoWay}"
                                     Label="{shuxm:ResourceString Name=ViewPageCultivationMaterialListIncompleteFirstLabel}"
                                     Visibility="{Binding ElementName=MaterialListPivot, Path=SelectedItem.Tag, Converter={StaticResource MaterialListSelectedItemIsStatisticsViewConverter}}"/>
+                                <AppBarToggleButton
+                                    Command="{Binding RefreshStatisticsItemsCommand}"
+                                    Icon="{shuxm:FontIcon Glyph=&#xE7C3;}"
+                                    IsChecked="{Binding MergeUpgradeMaterials, Mode=TwoWay}"
+                                    Label="{shuxm:ResourceString Name=ViewPageCultivationMergeUpgradeMaterialsLabel}"
+                                    Visibility="{Binding ElementName=MaterialListPivot, Path=SelectedItem.Tag, Converter={StaticResource MaterialListSelectedItemIsStatisticsViewConverter}}"/>
+                                <AppBarToggleButton
+                                    Command="{Binding RefreshStatisticsItemsCommand}"
+                                    Icon="{shuxm:FontIcon Glyph=&#xE9A1;}"
+                                    IsChecked="{Binding TalentSynthCritTenPercent, Mode=TwoWay}"
+                                    IsEnabled="{Binding MergeUpgradeMaterials}"
+                                    Label="{shuxm:ResourceString Name=ViewPageCultivationTalentSynthCritTenPercentLabel}"
+                                    Visibility="{Binding ElementName=MaterialListPivot, Path=SelectedItem.Tag, Converter={StaticResource MaterialListSelectedItemIsStatisticsViewConverter}}"/>
                                 <AppBarButton Icon="{shuxm:FontIcon Glyph=&#xE946;}" Label="{shuxm:ResourceString Name=ViewPageCultivationMaterialListResinStatisticsLabel}">
                                     <AppBarButton.Flyout>
                                         <Flyout FlyoutPresenterStyle="{ThemeResource FlyoutPresenterPadding0Style}" Placement="BottomEdgeAlignedRight">

--- a/src/Snap.Hutao/Snap.Hutao/UI/Xaml/View/Page/CultivationPage.xaml
+++ b/src/Snap.Hutao/Snap.Hutao/UI/Xaml/View/Page/CultivationPage.xaml
@@ -229,9 +229,21 @@
             <DataTemplate x:Key="StatisticsItemTemplate" x:DataType="shvcu:StatisticsCultivateItem">
                 <Border Background="Transparent" IsRightTapEnabled="True">
                     <Border.ContextFlyout>
-                        <MenuFlyout>
-                            <MenuFlyoutItem IsEnabled="False" MaxWidth="360" Text="{Binding StatisticsConsumerMenuText, Mode=OneWay}"/>
-                        </MenuFlyout>
+                        <Flyout FlyoutPresenterStyle="{ThemeResource FlyoutPresenterPadding0Style}">
+                            <ScrollViewer MaxHeight="320" MinWidth="220" Padding="12,10">
+                                <ItemsControl ItemsSource="{Binding StatisticsConsumerMenuLines, Mode=OneWay}">
+                                    <ItemsControl.ItemTemplate>
+                                        <DataTemplate x:DataType="x:String">
+                                            <TextBlock
+                                                Margin="0,3"
+                                                Style="{ThemeResource BodyTextBlockStyle}"
+                                                Text="{x:Bind Mode=OneWay}"
+                                                TextWrapping="WrapWholeWords"/>
+                                        </DataTemplate>
+                                    </ItemsControl.ItemTemplate>
+                                </ItemsControl>
+                            </ScrollViewer>
+                        </Flyout>
                     </Border.ContextFlyout>
                     <shuxcc:HorizontalCard Background="{Binding IsToday, Converter={ThemeResource BoolToStatisticsBrushSelector}}">
                     <shuxcc:HorizontalCard.Left>

--- a/src/Snap.Hutao/Snap.Hutao/UI/Xaml/View/Page/CultivationPage.xaml
+++ b/src/Snap.Hutao/Snap.Hutao/UI/Xaml/View/Page/CultivationPage.xaml
@@ -227,7 +227,13 @@
             </DataTemplate>
 
             <DataTemplate x:Key="StatisticsItemTemplate" x:DataType="shvcu:StatisticsCultivateItem">
-                <shuxcc:HorizontalCard Background="{Binding IsToday, Converter={ThemeResource BoolToStatisticsBrushSelector}}">
+                <Border Background="Transparent" IsRightTapEnabled="True">
+                    <Border.ContextFlyout>
+                        <MenuFlyout>
+                            <MenuFlyoutItem IsEnabled="False" MaxWidth="360" Text="{Binding StatisticsConsumerMenuText, Mode=OneWay}"/>
+                        </MenuFlyout>
+                    </Border.ContextFlyout>
+                    <shuxcc:HorizontalCard Background="{Binding IsToday, Converter={ThemeResource BoolToStatisticsBrushSelector}}">
                     <shuxcc:HorizontalCard.Left>
                         <Grid Grid.Column="0">
                             <shuxc:ItemIcon
@@ -293,6 +299,7 @@
                         </Grid>
                     </shuxcc:HorizontalCard.Right>
                 </shuxcc:HorizontalCard>
+                </Border>
             </DataTemplate>
 
             <DataTemplate x:Key="InventoryItemTemplate" x:DataType="shvcu:InventoryItemView">

--- a/src/Snap.Hutao/Snap.Hutao/ViewModel/AvatarProperty/AvatarPropertyViewModel.cs
+++ b/src/Snap.Hutao/Snap.Hutao/ViewModel/AvatarProperty/AvatarPropertyViewModel.cs
@@ -335,9 +335,9 @@ internal sealed partial class AvatarPropertyViewModel : Abstraction.ViewModel, I
             Strategy = options.Strategy,
         };
 
-        ConsumptionSaveResultKind avatarSaveKind = await scopeContext.CultivationService.SaveConsumptionAsync(avatarInput).ConfigureAwait(false);
+        ConsumptionSaveResult avatarSave = await scopeContext.CultivationService.SaveConsumptionAsync(avatarInput).ConfigureAwait(false);
 
-        InfoBarMessage? avatarMessage = avatarSaveKind switch
+        InfoBarMessage? avatarMessage = avatarSave.Kind switch
         {
             ConsumptionSaveResultKind.NoProject => InfoBarMessage.Warning(SH.ViewModelCultivationEntryAddWarning),
             ConsumptionSaveResultKind.Skipped => isBatch ? default : InfoBarMessage.Information(SH.ViewModelCultivationConsumptionSaveSkippedHint),
@@ -351,12 +351,18 @@ internal sealed partial class AvatarPropertyViewModel : Abstraction.ViewModel, I
             scopeContext.Messenger.Send(avatarMessage);
         }
 
-        if (avatarSaveKind is ConsumptionSaveResultKind.NoProject)
+        if (avatarSave.Kind is ConsumptionSaveResultKind.NoProject)
         {
             return false;
         }
 
         ArgumentNullException.ThrowIfNull(options.Delta.Weapon);
+
+        Guid? relatedAvatarEntryId = avatarSave.CreatedEntryInnerId;
+        if (relatedAvatarEntryId is null && avatarSave.Kind is ConsumptionSaveResultKind.Skipped)
+        {
+            relatedAvatarEntryId = await scopeContext.CultivationService.TryGetAvatarCultivateEntryInnerIdAsync(options.Delta.AvatarId).ConfigureAwait(false);
+        }
 
         InputConsumption weaponInput = new()
         {
@@ -365,10 +371,11 @@ internal sealed partial class AvatarPropertyViewModel : Abstraction.ViewModel, I
             Items = consumption.WeaponConsume,
             LevelInformation = levelInformation,
             Strategy = options.Strategy,
+            RelatedEntryId = relatedAvatarEntryId,
         };
 
-        ConsumptionSaveResultKind weaponSaveKind = await scopeContext.CultivationService.SaveConsumptionAsync(weaponInput).ConfigureAwait(false);
-        InfoBarMessage? weaponMessage = weaponSaveKind switch
+        ConsumptionSaveResult weaponSave = await scopeContext.CultivationService.SaveConsumptionAsync(weaponInput).ConfigureAwait(false);
+        InfoBarMessage? weaponMessage = weaponSave.Kind switch
         {
             ConsumptionSaveResultKind.NoProject => InfoBarMessage.Warning(SH.ViewModelCultivationEntryAddWarning),
             ConsumptionSaveResultKind.Skipped => isBatch ? default : InfoBarMessage.Information(SH.ViewModelCultivationConsumptionSaveSkippedHint),
@@ -382,7 +389,7 @@ internal sealed partial class AvatarPropertyViewModel : Abstraction.ViewModel, I
             scopeContext.Messenger.Send(weaponMessage);
         }
 
-        return weaponSaveKind is not ConsumptionSaveResultKind.NoProject;
+        return weaponSave.Kind is not ConsumptionSaveResultKind.NoProject;
     }
 
     [Command("ExportToTextCommand")]

--- a/src/Snap.Hutao/Snap.Hutao/ViewModel/AvatarProperty/AvatarPropertyViewModel.cs
+++ b/src/Snap.Hutao/Snap.Hutao/ViewModel/AvatarProperty/AvatarPropertyViewModel.cs
@@ -16,6 +16,7 @@ using Snap.Hutao.Service.AvatarInfo;
 using Snap.Hutao.Service.AvatarInfo.Factory;
 using Snap.Hutao.Service.Cultivation;
 using Snap.Hutao.Service.Cultivation.Consumption;
+using BatchCultivateResult = Snap.Hutao.Service.Cultivation.BatchCultivateResult;
 using Snap.Hutao.Service.Cultivation.Offline;
 using Snap.Hutao.Service.Metadata.ContextAbstraction;
 using Snap.Hutao.Service.Notification;
@@ -28,7 +29,6 @@ using Snap.Hutao.Web.Hoyolab.Takumi.Event.Calculate;
 using System.Collections.Immutable;
 using System.Globalization;
 using System.Runtime.CompilerServices;
-using CalculatorAvatarPromotionDelta = Snap.Hutao.Web.Hoyolab.Takumi.Event.Calculate.AvatarPromotionDelta;
 using CalculatorBatchConsumption = Snap.Hutao.Web.Hoyolab.Takumi.Event.Calculate.BatchConsumption;
 using CalculatorConsumption = Snap.Hutao.Web.Hoyolab.Takumi.Event.Calculate.Consumption;
 using CalculatorItemHelper = Snap.Hutao.Web.Hoyolab.Takumi.Event.Calculate.ItemHelper;
@@ -41,6 +41,7 @@ internal sealed partial class AvatarPropertyViewModel : Abstraction.ViewModel, I
 {
     private readonly ExclusiveTokenProvider refreshTokenProvider = new();
     private readonly AvatarPropertyViewModelScopeContext scopeContext;
+    private readonly IAvatarPropertyBatchCultivateService avatarPropertyBatchCultivateService;
 
     private SummaryFactoryMetadataContext? metadataContext;
 
@@ -270,67 +271,14 @@ internal sealed partial class AvatarPropertyViewModel : Abstraction.ViewModel, I
             targetAvatars = [.. avatars.Source];
         }
 
-        CultivateProjectAvatarPropertyBatchPreferences? batchPrefs = await scopeContext.CultivationService
-            .GetAvatarPropertyBatchCultivatePreferencesForCurrentProjectAsync()
+        ArgumentNullException.ThrowIfNull(metadataContext);
+        BatchCultivateResult? batchResult = await avatarPropertyBatchCultivateService
+            .ExecuteAsync(metadataContext, targetAvatars, CancellationToken)
             .ConfigureAwait(false);
 
-        CultivatePromotionDeltaBatchDialog dialog = batchPrefs is null
-            ? await scopeContext.ContentDialogFactory
-                .CreateInstanceAsync<CultivatePromotionDeltaBatchDialog>(scopeContext.ServiceProvider)
-                .ConfigureAwait(false)
-            : await scopeContext.ContentDialogFactory
-                .CreateInstanceAsync<CultivatePromotionDeltaBatchDialog>(scopeContext.ServiceProvider, batchPrefs)
-                .ConfigureAwait(false);
-
-        if (await dialog.GetPromotionDeltaBaselineAsync().ConfigureAwait(false) is not (true, { } baseline))
+        if (batchResult is not { } result)
         {
             return;
-        }
-
-        await scopeContext.CultivationService
-            .SaveAvatarPropertyBatchCultivatePreferencesForCurrentProjectAsync(ToAvatarPropertyBatchPreferences(baseline))
-            .ConfigureAwait(false);
-
-        ArgumentNullException.ThrowIfNull(baseline.Delta.Weapon);
-
-        ContentDialog progressDialog = await scopeContext.ContentDialogFactory
-            .CreateForIndeterminateProgressAsync(SH.ViewModelAvatarPropertyBatchCultivateProgressTitle)
-            .ConfigureAwait(false);
-
-        BatchCultivateResult result = default;
-        using (await scopeContext.ContentDialogFactory.BlockAsync(progressDialog).ConfigureAwait(false))
-        {
-            if (baseline.ClearAvatarAndWeaponEntriesBeforeSync)
-            {
-                await scopeContext.CultivationService.RemoveAvatarAndWeaponEntriesForCurrentProjectAsync().ConfigureAwait(false);
-            }
-
-            ImmutableArray<CalculatorAvatarPromotionDelta>.Builder deltasBuilder = ImmutableArray.CreateBuilder<CalculatorAvatarPromotionDelta>();
-            foreach (AvatarView avatar in targetAvatars)
-            {
-                if (!baseline.Delta.TryGetNonErrorCopy(avatar, out CalculatorAvatarPromotionDelta? copy))
-                {
-                    ++result.SkippedCount;
-                    continue;
-                }
-
-                deltasBuilder.Add(copy);
-            }
-
-            ImmutableArray<CalculatorAvatarPromotionDelta> deltas = deltasBuilder.ToImmutable();
-
-            ArgumentNullException.ThrowIfNull(metadataContext);
-            CalculatorBatchConsumption batchConsumption = OfflineCalculator.CalculateBatchConsumption(deltas, metadataContext);
-
-            foreach ((CalculatorConsumption consumption, CalculatorAvatarPromotionDelta delta) in batchConsumption.Items.Zip(deltas))
-            {
-                if (!await SaveCultivationAsync(consumption, new CultivatePromotionDeltaOptions(delta, baseline.Strategy), true).ConfigureAwait(false))
-                {
-                    break;
-                }
-
-                ++result.SucceedCount;
-            }
         }
 
         scopeContext.Messenger.Send(CultivationProjectEntriesChangedMessage.Empty);
@@ -340,31 +288,6 @@ internal sealed partial class AvatarPropertyViewModel : Abstraction.ViewModel, I
             : InfoBarMessage.Success(SH.FormatViewModelCultivationBatchAddCompleted(result.SucceedCount, result.SkippedCount));
 
         scopeContext.Messenger.Send(message);
-    }
-
-    private static CultivateProjectAvatarPropertyBatchPreferences ToAvatarPropertyBatchPreferences(CultivatePromotionDeltaOptions baseline)
-    {
-        CalculatorAvatarPromotionDelta d = baseline.Delta;
-        uint sa = 10;
-        uint se = 10;
-        uint sq = 10;
-        if (d.SkillList is [{ } a, { } e, { } q, ..])
-        {
-            sa = a.LevelTarget;
-            se = e.LevelTarget;
-            sq = q.LevelTarget;
-        }
-
-        return new CultivateProjectAvatarPropertyBatchPreferences
-        {
-            AvatarLevelTarget = d.AvatarLevelTarget,
-            SkillATarget = sa,
-            SkillETarget = se,
-            SkillQTarget = sq,
-            WeaponLevelTarget = d.Weapon?.LevelTarget ?? 90U,
-            ConsumptionSaveStrategyIndex = (int)baseline.Strategy,
-            ClearAvatarAndWeaponEntriesBeforeSync = baseline.ClearAvatarAndWeaponEntriesBeforeSync,
-        };
     }
 
     /// <returns><see langword="true"/> if we can continue saving consumptions, otherwise <see langword="false"/>.</returns>

--- a/src/Snap.Hutao/Snap.Hutao/ViewModel/AvatarProperty/AvatarPropertyViewModel.cs
+++ b/src/Snap.Hutao/Snap.Hutao/ViewModel/AvatarProperty/AvatarPropertyViewModel.cs
@@ -281,6 +281,12 @@ internal sealed partial class AvatarPropertyViewModel : Abstraction.ViewModel, I
             return;
         }
 
+        if (result.StopReason is not BatchCultivateStopReason.None)
+        {
+            scopeContext.Messenger.Send(InfoBarMessage.Warning(SH.ViewModelCultivationEntryAddWarning));
+            return;
+        }
+
         scopeContext.Messenger.Send(CultivationProjectEntriesChangedMessage.Empty);
 
         InfoBarMessage message = result.SkippedCount > 0

--- a/src/Snap.Hutao/Snap.Hutao/ViewModel/AvatarProperty/AvatarPropertyViewModel.cs
+++ b/src/Snap.Hutao/Snap.Hutao/ViewModel/AvatarProperty/AvatarPropertyViewModel.cs
@@ -364,6 +364,16 @@ internal sealed partial class AvatarPropertyViewModel : Abstraction.ViewModel, I
             relatedAvatarEntryId = await scopeContext.CultivationService.TryGetAvatarCultivateEntryInnerIdAsync(options.Delta.AvatarId).ConfigureAwait(false);
         }
 
+        if (relatedAvatarEntryId is null && avatarSave.Kind is ConsumptionSaveResultKind.NoItem)
+        {
+            relatedAvatarEntryId = await scopeContext.CultivationService.TryGetAvatarCultivateEntryInnerIdAsync(options.Delta.AvatarId).ConfigureAwait(false);
+        }
+
+        if (relatedAvatarEntryId is null && !consumption.WeaponConsume.IsEmpty)
+        {
+            relatedAvatarEntryId = await scopeContext.CultivationService.EnsureAvatarAssociationStubAsync(options.Delta.AvatarId, levelInformation).ConfigureAwait(false);
+        }
+
         InputConsumption weaponInput = new()
         {
             Type = CultivateType.Weapon,

--- a/src/Snap.Hutao/Snap.Hutao/ViewModel/AvatarProperty/AvatarPropertyViewModel.cs
+++ b/src/Snap.Hutao/Snap.Hutao/ViewModel/AvatarProperty/AvatarPropertyViewModel.cs
@@ -9,6 +9,7 @@ using Snap.Hutao.Core.Setting;
 using Snap.Hutao.Factory.ContentDialog;
 using Snap.Hutao.Model;
 using Snap.Hutao.Model.Calculable;
+using Snap.Hutao.Model.Cultivation;
 using Snap.Hutao.Model.Entity.Primitive;
 using Snap.Hutao.Service;
 using Snap.Hutao.Service.AvatarInfo;
@@ -269,14 +270,26 @@ internal sealed partial class AvatarPropertyViewModel : Abstraction.ViewModel, I
             targetAvatars = [.. avatars.Source];
         }
 
-        CultivatePromotionDeltaBatchDialog dialog = await scopeContext.ContentDialogFactory
-            .CreateInstanceAsync<CultivatePromotionDeltaBatchDialog>(scopeContext.ServiceProvider)
+        CultivateProjectAvatarPropertyBatchPreferences? batchPrefs = await scopeContext.CultivationService
+            .GetAvatarPropertyBatchCultivatePreferencesForCurrentProjectAsync()
             .ConfigureAwait(false);
+
+        CultivatePromotionDeltaBatchDialog dialog = batchPrefs is null
+            ? await scopeContext.ContentDialogFactory
+                .CreateInstanceAsync<CultivatePromotionDeltaBatchDialog>(scopeContext.ServiceProvider)
+                .ConfigureAwait(false)
+            : await scopeContext.ContentDialogFactory
+                .CreateInstanceAsync<CultivatePromotionDeltaBatchDialog>(scopeContext.ServiceProvider, batchPrefs)
+                .ConfigureAwait(false);
 
         if (await dialog.GetPromotionDeltaBaselineAsync().ConfigureAwait(false) is not (true, { } baseline))
         {
             return;
         }
+
+        await scopeContext.CultivationService
+            .SaveAvatarPropertyBatchCultivatePreferencesForCurrentProjectAsync(ToAvatarPropertyBatchPreferences(baseline))
+            .ConfigureAwait(false);
 
         ArgumentNullException.ThrowIfNull(baseline.Delta.Weapon);
 
@@ -327,6 +340,31 @@ internal sealed partial class AvatarPropertyViewModel : Abstraction.ViewModel, I
             : InfoBarMessage.Success(SH.FormatViewModelCultivationBatchAddCompleted(result.SucceedCount, result.SkippedCount));
 
         scopeContext.Messenger.Send(message);
+    }
+
+    private static CultivateProjectAvatarPropertyBatchPreferences ToAvatarPropertyBatchPreferences(CultivatePromotionDeltaOptions baseline)
+    {
+        CalculatorAvatarPromotionDelta d = baseline.Delta;
+        uint sa = 10;
+        uint se = 10;
+        uint sq = 10;
+        if (d.SkillList is [{ } a, { } e, { } q, ..])
+        {
+            sa = a.LevelTarget;
+            se = e.LevelTarget;
+            sq = q.LevelTarget;
+        }
+
+        return new CultivateProjectAvatarPropertyBatchPreferences
+        {
+            AvatarLevelTarget = d.AvatarLevelTarget,
+            SkillATarget = sa,
+            SkillETarget = se,
+            SkillQTarget = sq,
+            WeaponLevelTarget = d.Weapon?.LevelTarget ?? 90U,
+            ConsumptionSaveStrategyIndex = (int)baseline.Strategy,
+            ClearAvatarAndWeaponEntriesBeforeSync = baseline.ClearAvatarAndWeaponEntriesBeforeSync,
+        };
     }
 
     /// <returns><see langword="true"/> if we can continue saving consumptions, otherwise <see langword="false"/>.</returns>

--- a/src/Snap.Hutao/Snap.Hutao/ViewModel/AvatarProperty/AvatarPropertyViewModel.cs
+++ b/src/Snap.Hutao/Snap.Hutao/ViewModel/AvatarProperty/AvatarPropertyViewModel.cs
@@ -21,6 +21,7 @@ using Snap.Hutao.Service.Notification;
 using Snap.Hutao.Service.User;
 using Snap.Hutao.UI.Xaml.Control.AutoSuggestBox;
 using Snap.Hutao.UI.Xaml.View.Dialog;
+using Snap.Hutao.ViewModel.Cultivation;
 using Snap.Hutao.ViewModel.User;
 using Snap.Hutao.Web.Hoyolab.Takumi.Event.Calculate;
 using System.Collections.Immutable;
@@ -286,6 +287,11 @@ internal sealed partial class AvatarPropertyViewModel : Abstraction.ViewModel, I
         BatchCultivateResult result = default;
         using (await scopeContext.ContentDialogFactory.BlockAsync(progressDialog).ConfigureAwait(false))
         {
+            if (baseline.ClearAvatarAndWeaponEntriesBeforeSync)
+            {
+                await scopeContext.CultivationService.RemoveAvatarAndWeaponEntriesForCurrentProjectAsync().ConfigureAwait(false);
+            }
+
             ImmutableArray<CalculatorAvatarPromotionDelta>.Builder deltasBuilder = ImmutableArray.CreateBuilder<CalculatorAvatarPromotionDelta>();
             foreach (AvatarView avatar in targetAvatars)
             {
@@ -305,7 +311,7 @@ internal sealed partial class AvatarPropertyViewModel : Abstraction.ViewModel, I
 
             foreach ((CalculatorConsumption consumption, CalculatorAvatarPromotionDelta delta) in batchConsumption.Items.Zip(deltas))
             {
-                if (!await SaveCultivationAsync(consumption, new(delta, baseline.Strategy), true).ConfigureAwait(false))
+                if (!await SaveCultivationAsync(consumption, new CultivatePromotionDeltaOptions(delta, baseline.Strategy), true).ConfigureAwait(false))
                 {
                     break;
                 }
@@ -313,6 +319,8 @@ internal sealed partial class AvatarPropertyViewModel : Abstraction.ViewModel, I
                 ++result.SucceedCount;
             }
         }
+
+        scopeContext.Messenger.Send(CultivationProjectEntriesChangedMessage.Empty);
 
         InfoBarMessage message = result.SkippedCount > 0
             ? InfoBarMessage.Warning(SH.FormatViewModelCultivationBatchAddIncompleted(result.SucceedCount, result.SkippedCount))

--- a/src/Snap.Hutao/Snap.Hutao/ViewModel/Cultivation/CultivateEntryView.cs
+++ b/src/Snap.Hutao/Snap.Hutao/ViewModel/Cultivation/CultivateEntryView.cs
@@ -14,7 +14,7 @@ namespace Snap.Hutao.ViewModel.Cultivation;
 
 internal sealed partial class CultivateEntryView : Item, IPropertyValuesProvider
 {
-    private CultivateEntryView(CultivateEntry entry, Item item, ImmutableArray<CultivateItemView> items)
+    private CultivateEntryView(CultivateEntry entry, Item item, ImmutableArray<CultivateItemView> items, string? relatedAvatarName)
     {
         Id = entry.Id;
         EntryId = entry.InnerId;
@@ -24,6 +24,8 @@ internal sealed partial class CultivateEntryView : Item, IPropertyValuesProvider
         Quality = item.Quality;
         Items = items;
         Type = entry.Type;
+
+        RelatedAvatarLine = relatedAvatarName is { } name ? SH.FormatViewModelCultivationEntryRelatedAvatar(name) : null;
 
         Description = ParseDescription(entry);
         IsToday = items.Any(i => i.IsToday);
@@ -110,12 +112,17 @@ internal sealed partial class CultivateEntryView : Item, IPropertyValuesProvider
 
     public string Description { get; }
 
+    /// <summary>
+    /// 武器条目在养成计算中与角色条目关联时的展示文案（含本地化前缀）。
+    /// </summary>
+    public string? RelatedAvatarLine { get; }
+
     internal Guid EntryId { get; }
 
     internal CultivateType Type { get; }
 
-    public static CultivateEntryView Create(CultivateEntry entry, Item item, ImmutableArray<CultivateItemView> items)
+    public static CultivateEntryView Create(CultivateEntry entry, Item item, ImmutableArray<CultivateItemView> items, string? relatedAvatarName = null)
     {
-        return new(entry, item, items);
+        return new(entry, item, items, relatedAvatarName);
     }
 }

--- a/src/Snap.Hutao/Snap.Hutao/ViewModel/Cultivation/CultivationProjectEntriesChangedMessage.cs
+++ b/src/Snap.Hutao/Snap.Hutao/ViewModel/Cultivation/CultivationProjectEntriesChangedMessage.cs
@@ -1,0 +1,16 @@
+// Copyright (c) DGP Studio. All rights reserved.
+// Licensed under the MIT license.
+
+namespace Snap.Hutao.ViewModel.Cultivation;
+
+/// <summary>
+/// 当前养成计划的条目在 UI 外被批量变更（例如从「我的角色」同步）后，通知养成页刷新列表与统计。
+/// </summary>
+internal sealed class CultivationProjectEntriesChangedMessage
+{
+    public static readonly CultivationProjectEntriesChangedMessage Empty = new();
+
+    private CultivationProjectEntriesChangedMessage()
+    {
+    }
+}

--- a/src/Snap.Hutao/Snap.Hutao/ViewModel/Cultivation/CultivationViewModel.cs
+++ b/src/Snap.Hutao/Snap.Hutao/ViewModel/Cultivation/CultivationViewModel.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Messaging;
 using Microsoft.UI.Xaml.Controls;
 using Snap.Hutao.Core;
 using Snap.Hutao.Core.Database;
@@ -29,7 +30,7 @@ namespace Snap.Hutao.ViewModel.Cultivation;
 [SuppressMessage("", "CA1001")]
 [BindableCustomPropertyProvider]
 [Service(ServiceLifetime.Scoped)]
-internal sealed partial class CultivationViewModel : Abstraction.ViewModel
+internal sealed partial class CultivationViewModel : Abstraction.ViewModel, IRecipient<CultivationProjectEntriesChangedMessage>
 {
     private readonly ExclusiveTokenProvider exclusiveTokenProvider = new();
 
@@ -130,6 +131,17 @@ internal sealed partial class CultivationViewModel : Abstraction.ViewModel
     private void OnCurrentProjectChanged(object? sender, object? e)
     {
         UpdateEntryCollectionAsync(Projects?.CurrentItem).SafeForget();
+    }
+
+    public async void Receive(CultivationProjectEntriesChangedMessage message)
+    {
+        await taskContext.SwitchToMainThreadAsync();
+        if (Projects?.CurrentItem is null)
+        {
+            return;
+        }
+
+        await UpdateEntryCollectionAsync(Projects.CurrentItem).ConfigureAwait(false);
     }
 
     [Command("AddProjectCommand")]

--- a/src/Snap.Hutao/Snap.Hutao/ViewModel/Cultivation/CultivationViewModel.cs
+++ b/src/Snap.Hutao/Snap.Hutao/ViewModel/Cultivation/CultivationViewModel.cs
@@ -78,6 +78,9 @@ internal sealed partial class CultivationViewModel : Abstraction.ViewModel
     public partial bool TalentSynthCritTenPercent { get; set; } = LocalSetting.Get(SettingKeys.CultivationStatisticsTalentSynthCritTenPercent, false);
 
     [ObservableProperty]
+    public partial bool WeeklyBossMaterialInterchange { get; set; } = LocalSetting.Get(SettingKeys.CultivationStatisticsWeeklyBossMaterialInterchange, false);
+
+    [ObservableProperty]
     public partial ObservableCollection<StatisticsCultivateItem>? StatisticsItems { get; set; }
 
     [ObservableProperty]
@@ -365,8 +368,10 @@ internal sealed partial class CultivationViewModel : Abstraction.ViewModel
 
         bool merge = MergeUpgradeMaterials;
         bool talentCrit = merge && TalentSynthCritTenPercent;
+        bool weeklyBoss = WeeklyBossMaterialInterchange;
         LocalSetting.Set(SettingKeys.CultivationStatisticsMergeUpgradeMaterials, merge);
         LocalSetting.Set(SettingKeys.CultivationStatisticsTalentSynthCritTenPercent, talentCrit);
+        LocalSetting.Set(SettingKeys.CultivationStatisticsWeeklyBossMaterialInterchange, weeklyBoss);
 
         CancellationToken token = exclusiveTokenProvider.GetNewToken();
         StatisticsCultivateItemCollection statistics;
@@ -374,7 +379,7 @@ internal sealed partial class CultivationViewModel : Abstraction.ViewModel
         try
         {
             statistics = await cultivationService
-                .GetStatisticsCultivateItemCollectionAsync(Projects.CurrentItem, metadataContext, new CultivationStatisticsMergeOptions(merge, talentCrit), token)
+                .GetStatisticsCultivateItemCollectionAsync(Projects.CurrentItem, metadataContext, new CultivationStatisticsMergeOptions(merge, talentCrit, weeklyBoss), token)
                 .ConfigureAwait(false);
             resinStatistics = await cultivationService.GetResinStatisticsAsync(statistics, token).ConfigureAwait(false);
         }

--- a/src/Snap.Hutao/Snap.Hutao/ViewModel/Cultivation/CultivationViewModel.cs
+++ b/src/Snap.Hutao/Snap.Hutao/ViewModel/Cultivation/CultivationViewModel.cs
@@ -149,7 +149,12 @@ internal sealed partial class CultivationViewModel : Abstraction.ViewModel, IRec
         LocalSetting.Set(SettingKeys.CultivationRefreshInventoryByCalculatorToAllProjects, value);
     }
 
-    public async void Receive(CultivationProjectEntriesChangedMessage message)
+    public void Receive(CultivationProjectEntriesChangedMessage _)
+    {
+        ReceiveProjectEntriesChangedAsync().SafeForget();
+    }
+
+    private async ValueTask ReceiveProjectEntriesChangedAsync()
     {
         await taskContext.SwitchToMainThreadAsync();
         if (Projects?.CurrentItem is null)
@@ -379,6 +384,12 @@ internal sealed partial class CultivationViewModel : Abstraction.ViewModel, IRec
 
         if (batchResult is not { } result)
         {
+            return;
+        }
+
+        if (result.StopReason is not BatchCultivateStopReason.None)
+        {
+            messenger.Send(InfoBarMessage.Warning(SH.ViewModelCultivationEntryAddWarning));
             return;
         }
 

--- a/src/Snap.Hutao/Snap.Hutao/ViewModel/Cultivation/CultivationViewModel.cs
+++ b/src/Snap.Hutao/Snap.Hutao/ViewModel/Cultivation/CultivationViewModel.cs
@@ -103,6 +103,9 @@ internal sealed partial class CultivationViewModel : Abstraction.ViewModel, IRec
 
     protected override async ValueTask<bool> LoadOverrideAsync(CancellationToken token)
     {
+        messenger.UnregisterAll(this);
+        messenger.Register<CultivationProjectEntriesChangedMessage>(this);
+
         if (!await metadataService.InitializeAsync().ConfigureAwait(false))
         {
             return false;
@@ -133,6 +136,7 @@ internal sealed partial class CultivationViewModel : Abstraction.ViewModel, IRec
 
     protected override void UninitializeOverride()
     {
+        messenger.UnregisterAll(this);
         using (Projects?.SuppressChangeCurrentItem())
         {
             Projects = default;

--- a/src/Snap.Hutao/Snap.Hutao/ViewModel/Cultivation/CultivationViewModel.cs
+++ b/src/Snap.Hutao/Snap.Hutao/ViewModel/Cultivation/CultivationViewModel.cs
@@ -7,6 +7,7 @@ using Snap.Hutao.Core;
 using Snap.Hutao.Core.Database;
 using Snap.Hutao.Core.ExceptionService;
 using Snap.Hutao.Core.Logging;
+using Snap.Hutao.Core.Setting;
 using Snap.Hutao.Factory.ContentDialog;
 using Snap.Hutao.Model.Entity;
 using Snap.Hutao.Service.Cultivation;
@@ -69,6 +70,12 @@ internal sealed partial class CultivationViewModel : Abstraction.ViewModel
 
     [ObservableProperty]
     public partial bool IncompleteFirst { get; set; }
+
+    [ObservableProperty]
+    public partial bool MergeUpgradeMaterials { get; set; } = LocalSetting.Get(SettingKeys.CultivationStatisticsMergeUpgradeMaterials, false);
+
+    [ObservableProperty]
+    public partial bool TalentSynthCritTenPercent { get; set; } = LocalSetting.Get(SettingKeys.CultivationStatisticsTalentSynthCritTenPercent, false);
 
     [ObservableProperty]
     public partial ObservableCollection<StatisticsCultivateItem>? StatisticsItems { get; set; }
@@ -356,12 +363,19 @@ internal sealed partial class CultivationViewModel : Abstraction.ViewModel
 
         await taskContext.SwitchToBackgroundAsync();
 
+        bool merge = MergeUpgradeMaterials;
+        bool talentCrit = merge && TalentSynthCritTenPercent;
+        LocalSetting.Set(SettingKeys.CultivationStatisticsMergeUpgradeMaterials, merge);
+        LocalSetting.Set(SettingKeys.CultivationStatisticsTalentSynthCritTenPercent, talentCrit);
+
         CancellationToken token = exclusiveTokenProvider.GetNewToken();
         StatisticsCultivateItemCollection statistics;
         ResinStatistics resinStatistics;
         try
         {
-            statistics = await cultivationService.GetStatisticsCultivateItemCollectionAsync(Projects.CurrentItem, metadataContext, token).ConfigureAwait(false);
+            statistics = await cultivationService
+                .GetStatisticsCultivateItemCollectionAsync(Projects.CurrentItem, metadataContext, new CultivationStatisticsMergeOptions(merge, talentCrit), token)
+                .ConfigureAwait(false);
             resinStatistics = await cultivationService.GetResinStatisticsAsync(statistics, token).ConfigureAwait(false);
         }
         catch (OperationCanceledException)

--- a/src/Snap.Hutao/Snap.Hutao/ViewModel/Cultivation/CultivationViewModel.cs
+++ b/src/Snap.Hutao/Snap.Hutao/ViewModel/Cultivation/CultivationViewModel.cs
@@ -11,19 +11,24 @@ using Snap.Hutao.Core.Logging;
 using Snap.Hutao.Core.Setting;
 using Snap.Hutao.Factory.ContentDialog;
 using Snap.Hutao.Model.Entity;
+using Snap.Hutao.Service.AvatarInfo;
+using Snap.Hutao.Service.AvatarInfo.Factory;
 using Snap.Hutao.Service.Cultivation;
 using Snap.Hutao.Service.Inventory;
 using Snap.Hutao.Service.Metadata;
 using Snap.Hutao.Service.Metadata.ContextAbstraction;
 using Snap.Hutao.Service.Navigation;
 using Snap.Hutao.Service.Notification;
+using Snap.Hutao.Service.User;
 using Snap.Hutao.Service.Yae;
+using Snap.Hutao.ViewModel.AvatarProperty;
 using Snap.Hutao.UI.Xaml.Control.AutoSuggestBox;
 using Snap.Hutao.UI.Xaml.Data;
 using Snap.Hutao.UI.Xaml.View.Dialog;
 using Snap.Hutao.ViewModel.Game;
 using System.Collections.Immutable;
 using System.Collections.ObjectModel;
+using BatchCultivateResult = Snap.Hutao.Service.Cultivation.BatchCultivateResult;
 
 namespace Snap.Hutao.ViewModel.Cultivation;
 
@@ -38,6 +43,9 @@ internal sealed partial class CultivationViewModel : Abstraction.ViewModel, IRec
     private readonly ICultivationService cultivationService;
     private readonly INavigationService navigationService;
     private readonly IInventoryService inventoryService;
+    private readonly IAvatarInfoService avatarInfoService;
+    private readonly IAvatarPropertyBatchCultivateService avatarPropertyBatchCultivateService;
+    private readonly IUserService userService;
     private readonly IServiceProvider serviceProvider;
     private readonly IMetadataService metadataService;
     private readonly ITaskContext taskContext;
@@ -320,6 +328,57 @@ internal sealed partial class CultivationViewModel : Abstraction.ViewModel, IRec
                 await UpdateStatisticsItemsAsync().ConfigureAwait(false);
             }
         }
+    }
+
+    [Command("SyncAllAvatarsAndWeaponsCommand")]
+    private async Task SyncAllAvatarsAndWeaponsAsync()
+    {
+        SentrySdk.AddBreadcrumb(BreadcrumbFactory2.CreateUI("Sync all avatars and weapons to cultivation", "CultivationViewModel.Command", []));
+
+        if (Projects?.CurrentItem is null)
+        {
+            return;
+        }
+
+        if (await userService.GetCurrentUserAndUidAsync().ConfigureAwait(false) is not { } userAndUid)
+        {
+            messenger.Send(InfoBarMessage.Warning(SH.MustSelectUserAndUid));
+            return;
+        }
+
+        SummaryFactoryMetadataContext summaryContext = await metadataService.GetContextAsync<SummaryFactoryMetadataContext>(CancellationToken).ConfigureAwait(false);
+        Summary? summary = await avatarInfoService.GetSummaryAsync(summaryContext, userAndUid, global::Snap.Hutao.Service.AvatarInfo.RefreshOptionKind.None, CancellationToken).ConfigureAwait(false);
+
+        if (summary is not { Avatars: { } avatars })
+        {
+            messenger.Send(InfoBarMessage.Warning(SH.ViewPageAvatarPropertyDefaultDescription));
+            return;
+        }
+
+        if (avatars.Source.Count < 1)
+        {
+            messenger.Send(InfoBarMessage.Warning(SH.ViewPageAvatarPropertyDefaultDescription));
+            return;
+        }
+
+        ImmutableArray<AvatarView> targetAvatars = [.. avatars.Source];
+
+        BatchCultivateResult? batchResult = await avatarPropertyBatchCultivateService
+            .ExecuteAsync(summaryContext, targetAvatars, CancellationToken)
+            .ConfigureAwait(false);
+
+        if (batchResult is not { } result)
+        {
+            return;
+        }
+
+        messenger.Send(CultivationProjectEntriesChangedMessage.Empty);
+
+        InfoBarMessage message = result.SkippedCount > 0
+            ? InfoBarMessage.Warning(SH.FormatViewModelCultivationBatchAddIncompleted(result.SucceedCount, result.SkippedCount))
+            : InfoBarMessage.Success(SH.FormatViewModelCultivationBatchAddCompleted(result.SucceedCount, result.SkippedCount));
+
+        messenger.Send(message);
     }
 
     [Command("ClearInventoryCommand")]

--- a/src/Snap.Hutao/Snap.Hutao/ViewModel/Cultivation/CultivationViewModel.cs
+++ b/src/Snap.Hutao/Snap.Hutao/ViewModel/Cultivation/CultivationViewModel.cs
@@ -90,6 +90,9 @@ internal sealed partial class CultivationViewModel : Abstraction.ViewModel, IRec
     public partial bool WeeklyBossMaterialInterchange { get; set; } = LocalSetting.Get(SettingKeys.CultivationStatisticsWeeklyBossMaterialInterchange, false);
 
     [ObservableProperty]
+    public partial bool SyncInventoryByCalculatorToAllProjects { get; set; } = LocalSetting.Get(SettingKeys.CultivationRefreshInventoryByCalculatorToAllProjects, false);
+
+    [ObservableProperty]
     public partial ObservableCollection<StatisticsCultivateItem>? StatisticsItems { get; set; }
 
     [ObservableProperty]
@@ -139,6 +142,11 @@ internal sealed partial class CultivationViewModel : Abstraction.ViewModel, IRec
     private void OnCurrentProjectChanged(object? sender, object? e)
     {
         UpdateEntryCollectionAsync(Projects?.CurrentItem).SafeForget();
+    }
+
+    partial void OnSyncInventoryByCalculatorToAllProjectsChanged(bool value)
+    {
+        LocalSetting.Set(SettingKeys.CultivationRefreshInventoryByCalculatorToAllProjects, value);
     }
 
     public async void Receive(CultivationProjectEntriesChangedMessage message)
@@ -322,7 +330,9 @@ internal sealed partial class CultivationViewModel : Abstraction.ViewModel, IRec
 
             using (await contentDialogFactory.BlockAsync(dialog).ConfigureAwait(false))
             {
-                await inventoryService.RefreshInventoryAsync(RefreshOptions.CreateForWebCalculator(Projects.CurrentItem, metadataContext)).ConfigureAwait(false);
+                await inventoryService
+                    .RefreshInventoryAsync(RefreshOptions.CreateForWebCalculator(Projects.CurrentItem, metadataContext, SyncInventoryByCalculatorToAllProjects))
+                    .ConfigureAwait(false);
 
                 await UpdateInventoryItemsAsync().ConfigureAwait(false);
                 await UpdateStatisticsItemsAsync().ConfigureAwait(false);

--- a/src/Snap.Hutao/Snap.Hutao/ViewModel/Cultivation/StatisticsConsumerMenuLine.cs
+++ b/src/Snap.Hutao/Snap.Hutao/ViewModel/Cultivation/StatisticsConsumerMenuLine.cs
@@ -37,6 +37,7 @@ internal sealed class StatisticsConsumerMenuLine
 
     public string? SecondName { get; private init; }
 
+    /// <summary>计划需求量后缀，一般为全角括号包裹的数量 <c>（12）</c>。</summary>
     public string CountSuffix { get; private init; } = string.Empty;
 
     public static StatisticsConsumerMenuLine Plain(string message)

--- a/src/Snap.Hutao/Snap.Hutao/ViewModel/Cultivation/StatisticsConsumerMenuLine.cs
+++ b/src/Snap.Hutao/Snap.Hutao/ViewModel/Cultivation/StatisticsConsumerMenuLine.cs
@@ -1,0 +1,86 @@
+// Copyright (c) DGP Studio. All rights reserved.
+// Licensed under the MIT license.
+
+using Snap.Hutao.Model.Intrinsic;
+
+namespace Snap.Hutao.ViewModel.Cultivation;
+
+/// <summary>
+/// 材料统计右键浮层中一行「未完成」养成条目：名称前展示角色/武器图标。
+/// </summary>
+internal sealed class StatisticsConsumerMenuLine
+{
+    private StatisticsConsumerMenuLine()
+    {
+    }
+
+    public bool IsPlainMessage { get; private init; }
+
+    public string? PlainMessage { get; private init; }
+
+    public bool ShowRichRow => !IsPlainMessage;
+
+    public Uri LeadingIcon { get; private init; } = default!;
+
+    public QualityType LeadingQuality { get; private init; }
+
+    public bool HasSecondIcon { get; private init; }
+
+    public Uri SecondIcon { get; private init; } = default!;
+
+    public QualityType SecondQuality { get; private init; }
+
+    public string FirstName { get; private init; } = string.Empty;
+
+    /// <summary>双名称行中间分隔（与武器关联条目的「角色·武器」展示一致，使用间隔号）。</summary>
+    public string BetweenSeparator { get; private init; } = "\u00B7";
+
+    public string? SecondName { get; private init; }
+
+    public string CountSuffix { get; private init; } = string.Empty;
+
+    public static StatisticsConsumerMenuLine Plain(string message)
+    {
+        return new()
+        {
+            IsPlainMessage = true,
+            PlainMessage = message,
+        };
+    }
+
+    public static StatisticsConsumerMenuLine SingleIcon(Uri icon, QualityType quality, string name, string countSuffix)
+    {
+        return new()
+        {
+            LeadingIcon = icon,
+            LeadingQuality = quality,
+            FirstName = name,
+            CountSuffix = countSuffix,
+            HasSecondIcon = false,
+            SecondIcon = default!,
+            SecondQuality = QualityType.QUALITY_NONE,
+        };
+    }
+
+    public static StatisticsConsumerMenuLine AvatarAndWeapon(
+        Uri avatarIcon,
+        QualityType avatarQuality,
+        string avatarName,
+        Uri weaponIcon,
+        QualityType weaponQuality,
+        string weaponName,
+        string countSuffix)
+    {
+        return new()
+        {
+            LeadingIcon = avatarIcon,
+            LeadingQuality = avatarQuality,
+            FirstName = avatarName,
+            HasSecondIcon = true,
+            SecondIcon = weaponIcon,
+            SecondQuality = weaponQuality,
+            SecondName = weaponName,
+            CountSuffix = countSuffix,
+        };
+    }
+}

--- a/src/Snap.Hutao/Snap.Hutao/ViewModel/Cultivation/StatisticsCultivateItem.cs
+++ b/src/Snap.Hutao/Snap.Hutao/ViewModel/Cultivation/StatisticsCultivateItem.cs
@@ -40,6 +40,27 @@ internal sealed class StatisticsCultivateItem
 
     public string FormattedCount { get => $"{DisplayCurrent}/{Count}"; }
 
+    /// <summary>未启用合并展示链时，使用紧凑 <see cref="FormattedCount"/>。</summary>
+    public bool ShowNonMergeCompactCount { get => !MergeAdjustedCurrent.HasValue; }
+
+    /// <summary>已合并但合成前后有效持有量与背包数一致，不显示括号，仅「合并后 / 需求」加空格。</summary>
+    public bool ShowMergeSpacedWithoutParen { get => MergeAdjustedCurrent.HasValue && DisplayCurrent == Current; }
+
+    /// <summary>合并后有效持有与背包原数不同，显示「(背包原数)」并着色。</summary>
+    public bool ShowMergeInventoryParen { get => MergeAdjustedCurrent.HasValue && DisplayCurrent != Current; }
+
+    /// <summary>合并后 &gt; 背包原数：括号用强调色（蓝系）。</summary>
+    public bool MergeInventoryParenUseBlue { get => MergeAdjustedCurrent.HasValue && DisplayCurrent > Current; }
+
+    /// <summary>合并后 &lt; 背包原数：括号用警告色（红系，低级被向上消耗）。</summary>
+    public bool MergeInventoryParenUseRed { get => MergeAdjustedCurrent.HasValue && DisplayCurrent < Current; }
+
+    /// <summary>背包同步原数，带前导空格与括号。</summary>
+    public string RawInventoryParenthetical { get => $" ({Current})"; }
+
+    /// <summary>「 / 需求数」段，含前导空格。</summary>
+    public string SlashCountSuffix { get => $" / {Count}"; }
+
     public bool IsToday { get => Inner.IsItemOfToday(offset, true); }
 
     internal bool ExcludedFromPresentation { get; set; }

--- a/src/Snap.Hutao/Snap.Hutao/ViewModel/Cultivation/StatisticsCultivateItem.cs
+++ b/src/Snap.Hutao/Snap.Hutao/ViewModel/Cultivation/StatisticsCultivateItem.cs
@@ -29,9 +29,16 @@ internal sealed class StatisticsCultivateItem
 
     public uint Current { get; set; }
 
-    public bool IsFinished { get => Current >= Count; }
+    /// <summary>
+    /// 升级材料合并后的展示用持有量；未启用合并时为 <see langword="null"/>。
+    /// </summary>
+    public uint? MergeAdjustedCurrent { get; set; }
 
-    public string FormattedCount { get => $"{Current}/{Count}"; }
+    public uint DisplayCurrent { get => MergeAdjustedCurrent ?? Current; }
+
+    public bool IsFinished { get => DisplayCurrent >= Count; }
+
+    public string FormattedCount { get => $"{DisplayCurrent}/{Count}"; }
 
     public bool IsToday { get => Inner.IsItemOfToday(offset, true); }
 

--- a/src/Snap.Hutao/Snap.Hutao/ViewModel/Cultivation/StatisticsCultivateItem.cs
+++ b/src/Snap.Hutao/Snap.Hutao/ViewModel/Cultivation/StatisticsCultivateItem.cs
@@ -46,19 +46,22 @@ internal sealed class StatisticsCultivateItem
     /// <summary>已合并但合成前后有效持有量与背包数一致，不显示括号，仅「合并后 / 需求」加空格。</summary>
     public bool ShowMergeSpacedWithoutParen { get => MergeAdjustedCurrent.HasValue && DisplayCurrent == Current; }
 
-    /// <summary>合并后有效持有与背包原数不同，显示「(背包原数)」并着色。</summary>
+    /// <summary>合并后有效持有与背包原数不同，显示「合并后 (背包原数)」。</summary>
     public bool ShowMergeInventoryParen { get => MergeAdjustedCurrent.HasValue && DisplayCurrent != Current; }
 
-    /// <summary>合并后 &gt; 背包原数：括号用强调色（蓝系）。</summary>
-    public bool MergeInventoryParenUseBlue { get => MergeAdjustedCurrent.HasValue && DisplayCurrent > Current; }
+    /// <summary>首位合并显示量 &gt; 背包原数时着红色（相对原库存变多）。</summary>
+    public bool MergeDisplayLeadUseRed { get => MergeAdjustedCurrent.HasValue && DisplayCurrent > Current; }
 
-    /// <summary>合并后 &lt; 背包原数：括号用警告色（红系，低级被向上消耗）。</summary>
-    public bool MergeInventoryParenUseRed { get => MergeAdjustedCurrent.HasValue && DisplayCurrent < Current; }
+    /// <summary>首位合并显示量 &lt; 背包原数时着绿色（相对原库存变少，如低档被向上消耗）。</summary>
+    public bool MergeDisplayLeadUseGreen { get => MergeAdjustedCurrent.HasValue && DisplayCurrent < Current; }
 
-    /// <summary>背包同步原数，带前导空格与括号。</summary>
-    public string RawInventoryParenthetical { get => $" ({Current})"; }
+    /// <summary>背包原数，紧接在合并后数字后，如 <c>(44)</c>。</summary>
+    public string RawInventoryParenthetical { get => $"({Current})"; }
 
-    /// <summary>「 / 需求数」段，含前导空格。</summary>
+    /// <summary>有括号行：「/需求」紧接括号，如 <c>/55</c>。</summary>
+    public string SlashCountSuffixForParen { get => $"/{Count}"; }
+
+    /// <summary>无括号行：「 / 需求」含空格。</summary>
     public string SlashCountSuffix { get => $" / {Count}"; }
 
     public bool IsToday { get => Inner.IsItemOfToday(offset, true); }

--- a/src/Snap.Hutao/Snap.Hutao/ViewModel/Cultivation/StatisticsCultivateItem.cs
+++ b/src/Snap.Hutao/Snap.Hutao/ViewModel/Cultivation/StatisticsCultivateItem.cs
@@ -35,26 +35,33 @@ internal sealed class StatisticsCultivateItem
     /// </summary>
     public uint? MergeAdjustedCurrent { get; set; }
 
-    public uint DisplayCurrent { get => MergeAdjustedCurrent ?? Current; }
+    /// <summary>
+    /// 周本材料异梦转化池内调配后的展示用持有量；未启用时为 <see langword="null"/>。在 <see cref="MergeAdjustedCurrent"/> 之后应用。
+    /// </summary>
+    public uint? WeeklyBossInterchangeAdjustedCurrent { get; set; }
+
+    public uint DisplayCurrent { get => WeeklyBossInterchangeAdjustedCurrent ?? MergeAdjustedCurrent ?? Current; }
 
     public bool IsFinished { get => DisplayCurrent >= Count; }
 
     public string FormattedCount { get => $"{DisplayCurrent}/{Count}"; }
 
+    private bool HasStatisticsAdjustedDisplay { get => MergeAdjustedCurrent.HasValue || WeeklyBossInterchangeAdjustedCurrent.HasValue; }
+
     /// <summary>未启用合并展示链时，使用紧凑 <see cref="FormattedCount"/>。</summary>
-    public bool ShowNonMergeCompactCount { get => !MergeAdjustedCurrent.HasValue; }
+    public bool ShowNonMergeCompactCount { get => !HasStatisticsAdjustedDisplay; }
 
     /// <summary>已合并但合成前后有效持有量与背包数一致，不显示括号，仅「合并后 / 需求」加空格。</summary>
-    public bool ShowMergeSpacedWithoutParen { get => MergeAdjustedCurrent.HasValue && DisplayCurrent == Current; }
+    public bool ShowMergeSpacedWithoutParen { get => HasStatisticsAdjustedDisplay && DisplayCurrent == Current; }
 
     /// <summary>合并后有效持有与背包原数不同，显示「合并后 (背包原数)」。</summary>
-    public bool ShowMergeInventoryParen { get => MergeAdjustedCurrent.HasValue && DisplayCurrent != Current; }
+    public bool ShowMergeInventoryParen { get => HasStatisticsAdjustedDisplay && DisplayCurrent != Current; }
 
     /// <summary>首位合并显示量 &gt; 背包原数时着红色（相对原库存变多）。</summary>
-    public bool MergeDisplayLeadUseRed { get => MergeAdjustedCurrent.HasValue && DisplayCurrent > Current; }
+    public bool MergeDisplayLeadUseRed { get => HasStatisticsAdjustedDisplay && DisplayCurrent > Current; }
 
     /// <summary>首位合并显示量 &lt; 背包原数时着绿色（相对原库存变少，如低档被向上消耗）。</summary>
-    public bool MergeDisplayLeadUseGreen { get => MergeAdjustedCurrent.HasValue && DisplayCurrent < Current; }
+    public bool MergeDisplayLeadUseGreen { get => HasStatisticsAdjustedDisplay && DisplayCurrent < Current; }
 
     /// <summary>背包原数，紧接在合并后数字后，如 <c>(44)</c>。</summary>
     public string RawInventoryParenthetical { get => $"({Current})"; }

--- a/src/Snap.Hutao/Snap.Hutao/ViewModel/Cultivation/StatisticsCultivateItem.cs
+++ b/src/Snap.Hutao/Snap.Hutao/ViewModel/Cultivation/StatisticsCultivateItem.cs
@@ -68,9 +68,9 @@ internal sealed class StatisticsCultivateItem
     public bool IsToday { get => Inner.IsItemOfToday(offset, true); }
 
     /// <summary>
-    /// 材料统计右键浮层中按行展示的「未完成」养成条目（每人一行，<c>名×数量</c>）。
+    /// 材料统计右键浮层中按行展示的「未完成」养成条目（每人一行，名称前为角色/武器图标，<c>名×数量</c>）。
     /// </summary>
-    public ImmutableArray<string> StatisticsConsumerMenuLines { get; set; }
+    public ImmutableArray<StatisticsConsumerMenuLine> StatisticsConsumerMenuLines { get; set; }
 
     internal bool ExcludedFromPresentation { get; set; }
 

--- a/src/Snap.Hutao/Snap.Hutao/ViewModel/Cultivation/StatisticsCultivateItem.cs
+++ b/src/Snap.Hutao/Snap.Hutao/ViewModel/Cultivation/StatisticsCultivateItem.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 using Snap.Hutao.Model.Metadata.Item;
+using System.Collections.Immutable;
 
 namespace Snap.Hutao.ViewModel.Cultivation;
 
@@ -67,9 +68,9 @@ internal sealed class StatisticsCultivateItem
     public bool IsToday { get => Inner.IsItemOfToday(offset, true); }
 
     /// <summary>
-    /// 材料统计右键菜单中展示的「未完成」养成条目说明（含需求量）。
+    /// 材料统计右键浮层中按行展示的「未完成」养成条目（每人一行，<c>名×数量</c>）。
     /// </summary>
-    public string StatisticsConsumerMenuText { get; set; } = string.Empty;
+    public ImmutableArray<string> StatisticsConsumerMenuLines { get; set; }
 
     internal bool ExcludedFromPresentation { get; set; }
 

--- a/src/Snap.Hutao/Snap.Hutao/ViewModel/Cultivation/StatisticsCultivateItem.cs
+++ b/src/Snap.Hutao/Snap.Hutao/ViewModel/Cultivation/StatisticsCultivateItem.cs
@@ -68,7 +68,7 @@ internal sealed class StatisticsCultivateItem
     public bool IsToday { get => Inner.IsItemOfToday(offset, true); }
 
     /// <summary>
-    /// 材料统计右键浮层中按行展示的「未完成」养成条目（每人一行，名称前为角色/武器图标，<c>名×数量</c>）。
+    /// 材料统计右键浮层中按行展示的「未完成」养成条目（每人一行，名称前为角色/武器图标，需求量以括号标注）。
     /// </summary>
     public ImmutableArray<StatisticsConsumerMenuLine> StatisticsConsumerMenuLines { get; set; }
 

--- a/src/Snap.Hutao/Snap.Hutao/ViewModel/Cultivation/StatisticsCultivateItem.cs
+++ b/src/Snap.Hutao/Snap.Hutao/ViewModel/Cultivation/StatisticsCultivateItem.cs
@@ -66,6 +66,11 @@ internal sealed class StatisticsCultivateItem
 
     public bool IsToday { get => Inner.IsItemOfToday(offset, true); }
 
+    /// <summary>
+    /// 材料统计右键菜单中展示的「未完成」养成条目说明（含需求量）。
+    /// </summary>
+    public string StatisticsConsumerMenuText { get; set; } = string.Empty;
+
     internal bool ExcludedFromPresentation { get; set; }
 
     public static StatisticsCultivateItem Create(Material inner, TimeSpan offset)

--- a/src/Snap.Hutao/Snap.Hutao/ViewModel/Wiki/WikiAvatarViewModel.cs
+++ b/src/Snap.Hutao/Snap.Hutao/ViewModel/Wiki/WikiAvatarViewModel.cs
@@ -155,7 +155,7 @@ internal sealed partial class WikiAvatarViewModel : Abstraction.ViewModel
                 Strategy = deltaOptions.Strategy,
             };
 
-            InfoBarMessage? message = await cultivationService.SaveConsumptionAsync(input).ConfigureAwait(false) switch
+            InfoBarMessage? message = (await cultivationService.SaveConsumptionAsync(input).ConfigureAwait(false)).Kind switch
             {
                 ConsumptionSaveResultKind.NoProject => InfoBarMessage.Warning(SH.ViewModelCultivationEntryAddWarning),
                 ConsumptionSaveResultKind.Skipped => InfoBarMessage.Information(SH.ViewModelCultivationConsumptionSaveSkippedHint),

--- a/src/Snap.Hutao/Snap.Hutao/ViewModel/Wiki/WikiWeaponViewModel.cs
+++ b/src/Snap.Hutao/Snap.Hutao/ViewModel/Wiki/WikiWeaponViewModel.cs
@@ -146,7 +146,7 @@ internal sealed partial class WikiWeaponViewModel : Abstraction.ViewModel
                 Strategy = deltaOptions.Strategy,
             };
 
-            InfoBarMessage? message = await cultivationService.SaveConsumptionAsync(input).ConfigureAwait(false) switch
+            InfoBarMessage? message = (await cultivationService.SaveConsumptionAsync(input).ConfigureAwait(false)).Kind switch
             {
                 ConsumptionSaveResultKind.NoProject => InfoBarMessage.Warning(SH.ViewModelCultivationEntryAddWarning),
                 ConsumptionSaveResultKind.Skipped => InfoBarMessage.Information(SH.ViewModelCultivationConsumptionSaveSkippedHint),


### PR DESCRIPTION
1、材料统计 支持查看 升级材料合并后 和 角色天赋（10%双倍合成）下，最终的物品缺少项
2、材料统计中，针对物品缺少项，右键可显示，哪些人，武器缺多少该材料
3、调整材料统计中世界boss材料和周本材料排序，使之不再混排

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增三项统计切换：升级材料合并、角色天赋（10%）、周本材料转化；添加“同步所有角色与武器”一键同步与批量养成导入/执行（可清空已有条目、同步背包/角色信息）
  * 统计项右键菜单支持查看未完成消费条目，支持头像·武器双列展示与关联角色显示

* **改进**
  * 统计显示会应用合并/互换后的数量并以颜色提示增减，排序与合并/互换算法优化
  * 刷新背包新增选项可选择将同步结果应用到所有养成计划

* **本地化**
  * 补充中/英/繁体界面文案与短标签，支持新功能文本显示
<!-- end of auto-generated comment: release notes by coderabbit.ai -->