### PR TITLE
Improve metadata repository sync resilience

### DIFF
--- a/src/Snap.Hutao/Snap.Hutao/Resource/Localization/SH.en.resx
+++ b/src/Snap.Hutao/Snap.Hutao/Resource/Localization/SH.en.resx
@@ -1106,6 +1106,12 @@ Space Available: {2}</value>
   <data name="ServiceGameSetMultiChannelUnauthorizedAccess" xml:space="preserve">
     <value>Unable to read or save profile, please try again in administrator mode</value>
   </data>
+  <data name="ServiceGitRepositoryProbingMirror" xml:space="preserve">
+    <value>Probing metadata mirror</value>
+  </data>
+  <data name="ServiceGitRepositoryRetryingMirror" xml:space="preserve">
+    <value>Retrying metadata mirror</value>
+  </data>
   <data name="ServiceHutaoUserGachaLogExpiredAt" xml:space="preserve">
     <value>Wish record uploading service is valid until</value>
   </data>

--- a/src/Snap.Hutao/Snap.Hutao/Resource/Localization/SH.resx
+++ b/src/Snap.Hutao/Snap.Hutao/Resource/Localization/SH.resx
@@ -1139,6 +1139,12 @@
   <data name="ServiceGitRepositoryOperationFailed" xml:space="preserve">
     <value>操作失败</value>
   </data>
+  <data name="ServiceGitRepositoryProbingMirror" xml:space="preserve">
+    <value>检查元数据镜像</value>
+  </data>
+  <data name="ServiceGitRepositoryRetryingMirror" xml:space="preserve">
+    <value>重试元数据镜像</value>
+  </data>
   <data name="ServiceGitRepositoryUpdatingExisting" xml:space="preserve">
     <value>检查元数据更新</value>
   </data>

--- a/src/Snap.Hutao/Snap.Hutao/Resource/Localization/SH.zh-Hant.resx
+++ b/src/Snap.Hutao/Snap.Hutao/Resource/Localization/SH.zh-Hant.resx
@@ -1106,6 +1106,12 @@
   <data name="ServiceGameSetMultiChannelUnauthorizedAccess" xml:space="preserve">
     <value>無法讀取或儲存設定檔案，請用系統管理員模式重試</value>
   </data>
+  <data name="ServiceGitRepositoryProbingMirror" xml:space="preserve">
+    <value>檢查後設資料鏡像</value>
+  </data>
+  <data name="ServiceGitRepositoryRetryingMirror" xml:space="preserve">
+    <value>重試後設資料鏡像</value>
+  </data>
   <data name="ServiceHutaoUserGachaLogExpiredAt" xml:space="preserve">
     <value>祈願記錄上傳服務有效期限至</value>
   </data>

--- a/src/Snap.Hutao/Snap.Hutao/Service/Git/GitRepositoryService.cs
+++ b/src/Snap.Hutao/Snap.Hutao/Service/Git/GitRepositoryService.cs
@@ -13,6 +13,8 @@ using Snap.Hutao.Web.Hutao.Response;
 using Snap.Hutao.Web.Response;
 using System.Collections.Immutable;
 using System.IO;
+using System.Net.Http;
+using System.Net.Http.Headers;
 
 namespace Snap.Hutao.Service.Git;
 
@@ -24,6 +26,11 @@ internal sealed partial class GitRepositoryService : IGitRepositoryService
     private readonly ILogger<GitRepositoryService> logger;
     private readonly IServiceProvider serviceProvider;
     private readonly ITaskContext taskContext;
+    private static readonly TimeSpan GitTransferInactivityTimeout = TimeSpan.FromSeconds(3);
+    private static readonly TimeSpan MirrorListRequestTimeout = TimeSpan.FromSeconds(6);
+    private const int MirrorProgressFailureLimit = 10;
+    private const int MirrorNoProgressFailureLimit = 3;
+    private const int MirrorListMaxAttempts = 3;
 
     [GeneratedConstructor]
     public partial GitRepositoryService(IServiceProvider serviceProvider);
@@ -49,18 +56,20 @@ internal sealed partial class GitRepositoryService : IGitRepositoryService
             ImmutableArray<GitRepository> infos;
             using (IServiceScope scope = serviceProvider.CreateScope())
             {
-                HutaoInfrastructureClient infrastructureClient = scope.ServiceProvider.GetRequiredService<HutaoInfrastructureClient>();
-                HutaoResponse<ImmutableArray<GitRepository>> response = await infrastructureClient.GetGitRepositoryAsync(name).ConfigureAwait(false);
-                if (!ResponseValidator.TryValidate(response, scope.ServiceProvider, out infos))
+                ImmutableArray<GitRepository>? fetchedInfos = await TryGetRepositoryInfosAsync(scope.ServiceProvider, name).ConfigureAwait(false);
+                if (fetchedInfos is not { } validInfos)
                 {
                     return new(false, default);
                 }
+
+                infos = validInfos;
             }
 
             string directory = Path.GetFullPath(Path.Combine(HutaoRuntime.GetDataRepositoryDirectory(), name));
             BackgroundActivity.BackgroundActivity activity = GetActivityByName(name);
 
             bool failed = false;
+            bool succeeded = false;
             List<Exception> exceptions = [];
             try
             {
@@ -69,22 +78,15 @@ internal sealed partial class GitRepositoryService : IGitRepositoryService
 
                 foreach (GitRepository info in RepositoryAffinity.Sort(infos))
                 {
-                    try
+                    if (!await ProbeRepositoryAsync(activity, info).ConfigureAwait(false))
                     {
-                        try
-                        {
-                            return EnsureRepository(activity, directory, info, false);
-                        }
-                        catch (Exception first)
-                        {
-                            logger.LogWarning(first, "[Metadata] Failed to update existing repository, fallback to reclone: Directory={Directory}, Url={Url}", directory, info.HttpsUrl.OriginalString);
-                            exceptions.Add(first);
-                            return EnsureRepository(activity, directory, info, true);
-                        }
+                        continue;
                     }
-                    catch (Exception second)
+
+                    if (TryEnsureRepositoryWithRetries(activity, directory, info, exceptions, out ValueResult<bool, ValueDirectory> ensuredRepository))
                     {
-                        exceptions.Add(second);
+                        succeeded = true;
+                        return ensuredRepository;
                     }
                 }
             }
@@ -95,7 +97,7 @@ internal sealed partial class GitRepositoryService : IGitRepositoryService
             }
             finally
             {
-                if (!failed)
+                if (!failed && succeeded)
                 {
                     await activity.NotifyAsync(taskContext).ConfigureAwait(false);
                     await activity.UpdateAsync(taskContext, SH.ServiceGitRepositoryOperationCompleted, true, false, false, false).ConfigureAwait(false);
@@ -108,11 +110,187 @@ internal sealed partial class GitRepositoryService : IGitRepositoryService
         }
     }
 
-    private ValueResult<bool, ValueDirectory> EnsureRepository(BackgroundActivity.BackgroundActivity activity, string directory, GitRepository info, bool forceInvalid)
+    private async ValueTask<ImmutableArray<GitRepository>?> TryGetRepositoryInfosAsync(IServiceProvider scopedServiceProvider, string name)
     {
-        // Increase & decrease count in the same method, so that crash in the middle can correctly count as failure.
-        RepositoryAffinity.IncreaseFailure(info);
+        HutaoInfrastructureClient infrastructureClient = scopedServiceProvider.GetRequiredService<HutaoInfrastructureClient>();
 
+        for (int attempt = 1; attempt <= MirrorListMaxAttempts; attempt++)
+        {
+            try
+            {
+                using CancellationTokenSource timeoutCts = new(MirrorListRequestTimeout);
+                HutaoResponse<ImmutableArray<GitRepository>> response = await infrastructureClient.GetGitRepositoryAsync(name, timeoutCts.Token).ConfigureAwait(false);
+
+                if (ResponseValidator.TryValidateWithoutUINotification(response, scopedServiceProvider, out ImmutableArray<GitRepository> infos))
+                {
+                    if (attempt > 1)
+                    {
+                        logger.LogInformation("[Metadata] Repository mirror list recovered: Name={Name}, Attempt={Attempt}", name, attempt);
+                    }
+
+                    return infos;
+                }
+
+                logger.LogWarning("[Metadata] Repository mirror list request returned invalid response: Name={Name}, Attempt={Attempt}/{MaxAttempts}, ReturnCode={ReturnCode}, Message={Message}",
+                    name,
+                    attempt,
+                    MirrorListMaxAttempts,
+                    response.ReturnCode,
+                    response.Message);
+            }
+            catch (OperationCanceledException ex)
+            {
+                logger.LogWarning(ex, "[Metadata] Repository mirror list request timed out: Name={Name}, Attempt={Attempt}/{MaxAttempts}, RequestTimeout={RequestTimeout}s",
+                    name,
+                    attempt,
+                    MirrorListMaxAttempts,
+                    MirrorListRequestTimeout.TotalSeconds);
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex, "[Metadata] Repository mirror list request failed: Name={Name}, Attempt={Attempt}/{MaxAttempts}",
+                    name,
+                    attempt,
+                    MirrorListMaxAttempts);
+            }
+        }
+
+        logger.LogError("[Metadata] Repository mirror list request exhausted retries: Name={Name}, Attempts={Attempts}", name, MirrorListMaxAttempts);
+        return default;
+    }
+
+    private async ValueTask<bool> ProbeRepositoryAsync(BackgroundActivity.BackgroundActivity activity, GitRepository info)
+    {
+        string probeUrl = $"{info.HttpsUrl.OriginalString.TrimEnd('/')}/info/refs?service=git-upload-pack";
+        logger.LogInformation("[Metadata] Probing repository mirror: Url={Url}", probeUrl);
+        activity.Update(taskContext, $"{SH.ServiceGitRepositoryProbingMirror}: {info.Name}", false, false, false, true);
+
+        try
+        {
+            using SocketsHttpHandler handler = new()
+            {
+                UseProxy = true,
+                Proxy = HttpProxyUsingSystemProxy.Instance,
+                ConnectTimeout = TimeSpan.FromSeconds(3),
+            };
+
+            using HttpClient client = new(handler)
+            {
+                Timeout = TimeSpan.FromSeconds(5),
+            };
+
+            using HttpRequestMessage request = new(HttpMethod.Get, probeUrl);
+            if (!string.IsNullOrEmpty(info.Token))
+            {
+                string credentials = Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes($"{info.Username}:{info.Token}"));
+                request.Headers.Authorization = new AuthenticationHeaderValue("Basic", credentials);
+            }
+
+            using HttpResponseMessage response = await client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead).ConfigureAwait(false);
+            if (!response.IsSuccessStatusCode)
+            {
+                logger.LogWarning("[Metadata] Probe failed: Url={Url}, StatusCode={StatusCode}", probeUrl, (int)response.StatusCode);
+                return false;
+            }
+
+            logger.LogInformation("[Metadata] Probe succeeded: Url={Url}", probeUrl);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "[Metadata] Probe failed: Url={Url}", probeUrl);
+            return false;
+        }
+    }
+
+    private bool TryEnsureRepositoryWithRetries(BackgroundActivity.BackgroundActivity activity, string directory, GitRepository info, List<Exception> exceptions, out ValueResult<bool, ValueDirectory> result)
+    {
+        int progressFailures = 0;
+        int noProgressFailures = 0;
+        bool forceInvalid = false;
+
+        while (true)
+        {
+            using GitTransferWatchdog watchdog = new(GitTransferInactivityTimeout);
+
+            try
+            {
+                result = EnsureRepository(activity, directory, info, forceInvalid, watchdog);
+                RepositoryAffinity.DecreaseFailure(info);
+                return true;
+            }
+            catch (Exception ex)
+            {
+                exceptions.Add(ex);
+
+                if (watchdog.WasSoftCanceled)
+                {
+                    if (watchdog.HasAnyProgress)
+                    {
+                        progressFailures++;
+                        noProgressFailures = 0;
+                        logger.LogWarning(ex, "[Metadata] Repository transfer stalled after progress, retrying same mirror: Failure={Failure}/{FailureLimit}, Directory={Directory}, Url={Url}",
+                            progressFailures,
+                            MirrorProgressFailureLimit,
+                            directory,
+                            info.HttpsUrl.OriginalString);
+
+                        if (progressFailures >= MirrorProgressFailureLimit)
+                        {
+                            logger.LogWarning("[Metadata] Switching mirror after {FailureLimit} stalled transfers with progress: Directory={Directory}, Url={Url}",
+                                MirrorProgressFailureLimit,
+                                directory,
+                                info.HttpsUrl.OriginalString);
+                            RepositoryAffinity.IncreaseFailure(info);
+                            result = default;
+                            return false;
+                        }
+
+                        activity.Update(taskContext, $"{SH.ServiceGitRepositoryRetryingMirror}: {info.Name}", false, false, false, true);
+                    }
+                    else
+                    {
+                        progressFailures = 0;
+                        noProgressFailures++;
+                        logger.LogWarning(ex, "[Metadata] Repository transfer made no progress before timeout: Failure={Failure}/{FailureLimit}, Directory={Directory}, Url={Url}",
+                            noProgressFailures,
+                            MirrorNoProgressFailureLimit,
+                            directory,
+                            info.HttpsUrl.OriginalString);
+
+                        if (noProgressFailures >= MirrorNoProgressFailureLimit)
+                        {
+                            logger.LogWarning("[Metadata] Switching mirror after {FailureLimit} consecutive no-progress failures: Directory={Directory}, Url={Url}",
+                                MirrorNoProgressFailureLimit,
+                                directory,
+                                info.HttpsUrl.OriginalString);
+                            RepositoryAffinity.IncreaseFailure(info);
+                            result = default;
+                            return false;
+                        }
+                    }
+
+                    forceInvalid |= !Repository.IsValid(directory);
+                    continue;
+                }
+
+                if (!forceInvalid)
+                {
+                    logger.LogWarning(ex, "[Metadata] Failed to update existing repository, fallback to reclone: Directory={Directory}, Url={Url}", directory, info.HttpsUrl.OriginalString);
+                    forceInvalid = true;
+                    continue;
+                }
+
+                logger.LogWarning(ex, "[Metadata] Repository operation failed on mirror: Directory={Directory}, Url={Url}", directory, info.HttpsUrl.OriginalString);
+                RepositoryAffinity.IncreaseFailure(info);
+                result = default;
+                return false;
+            }
+        }
+    }
+
+    private ValueResult<bool, ValueDirectory> EnsureRepository(BackgroundActivity.BackgroundActivity activity, string directory, GitRepository info, bool forceInvalid, GitTransferWatchdog watchdog)
+    {
         // Debug: Log the initial state
         bool isRepoValid = Repository.IsValid(directory);
         bool directoryExists = Directory.Exists(directory);
@@ -136,15 +314,33 @@ internal sealed partial class GitRepositoryService : IGitRepositoryService
                 {
                     Username = info.Username,
                     Password = info.Token,
-                },
+            },
             OnProgress = output =>
             {
+                if (!watchdog.TryReportProgress($"progress:{output}"))
+                {
+                    logger.LogWarning("[Metadata] Cancelling repository transfer after {TimeoutSeconds}s without progress: Directory={Directory}, Url={Url}",
+                        GitTransferInactivityTimeout.TotalSeconds,
+                        directory,
+                        info.HttpsUrl.OriginalString);
+                    return false;
+                }
+
                 int idx = output.AsSpan().IndexOfAny("\r\n");
                 activity.Update(taskContext, idx > 0 ? output.Substring(0, idx) : output, false, false, false, false);
                 return true;
             },
             OnTransferProgress = progress =>
             {
+                if (!watchdog.TryReportProgress($"transfer:{progress.ReceivedObjects}:{progress.TotalObjects}:{progress.ReceivedBytes}"))
+                {
+                    logger.LogWarning("[Metadata] Cancelling repository transfer after {TimeoutSeconds}s without progress: Directory={Directory}, Url={Url}",
+                        GitTransferInactivityTimeout.TotalSeconds,
+                        directory,
+                        info.HttpsUrl.OriginalString);
+                    return false;
+                }
+
                 double progressValue = progress.TotalObjects == 0 ? 0 : (double)progress.ReceivedObjects / progress.TotalObjects;
                 activity.Update(taskContext, $"{progress.ReceivedObjects}/{progress.TotalObjects}, {Converters.ToFileSizeString(progress.ReceivedBytes)}", false, false, true, false, progressValue);
                 return true;
@@ -171,6 +367,10 @@ internal sealed partial class GitRepositoryService : IGitRepositoryService
             Repository.AdvancedClone(info.HttpsUrl.OriginalString, directory, new(fetchOptions)
             {
                 Checkout = true,
+                OnCheckoutProgress = (path, completedSteps, totalSteps) =>
+                {
+                    watchdog.TryReportProgress($"checkout:{completedSteps}:{totalSteps}:{path}");
+                },
             });
 
             logger.LogInformation("[Metadata] Clone completed successfully");
@@ -217,7 +417,6 @@ internal sealed partial class GitRepositoryService : IGitRepositoryService
             logger.LogInformation("[Metadata] Update completed successfully");
         }
 
-        RepositoryAffinity.DecreaseFailure(info);
         return new(true, directory);
     }
 
@@ -229,5 +428,111 @@ internal sealed partial class GitRepositoryService : IGitRepositoryService
             "Snap.ContentDelivery" => backgroundActivityOptions.FullTrustInitialization,
             _ => backgroundActivityOptions.Default,
         };
+    }
+
+    private sealed class GitTransferWatchdog : IDisposable
+    {
+        private readonly CancellationTokenSource cancellationTokenSource = new();
+        private readonly Task monitorTask;
+        private readonly object syncRoot = new();
+        private readonly long timeoutMilliseconds;
+        private bool hasAnyProgress;
+        private bool cancelRequested;
+        private long lastProgressTick;
+        private string? lastProgressSignature;
+
+        public GitTransferWatchdog(TimeSpan timeout)
+        {
+            timeoutMilliseconds = (long)timeout.TotalMilliseconds;
+            lastProgressTick = Environment.TickCount64;
+            monitorTask = Task.Run(MonitorAsync);
+        }
+
+        public bool HasAnyProgress
+        {
+            get
+            {
+                lock (syncRoot)
+                {
+                    return hasAnyProgress;
+                }
+            }
+        }
+
+        public bool WasSoftCanceled
+        {
+            get
+            {
+                lock (syncRoot)
+                {
+                    return cancelRequested;
+                }
+            }
+        }
+
+        public bool TryReportProgress(string signature)
+        {
+            lock (syncRoot)
+            {
+                if (cancelRequested)
+                {
+                    return false;
+                }
+
+                if (!string.Equals(lastProgressSignature, signature, StringComparison.Ordinal))
+                {
+                    hasAnyProgress = true;
+                    lastProgressTick = Environment.TickCount64;
+                    lastProgressSignature = signature;
+                }
+
+                return true;
+            }
+        }
+
+        public void Dispose()
+        {
+            cancellationTokenSource.Cancel();
+
+            try
+            {
+                monitorTask.Wait(TimeSpan.FromSeconds(1));
+            }
+            catch (AggregateException)
+            {
+            }
+            finally
+            {
+                cancellationTokenSource.Dispose();
+            }
+        }
+
+        private async Task MonitorAsync()
+        {
+            try
+            {
+                while (!cancellationTokenSource.IsCancellationRequested)
+                {
+                    await Task.Delay(250, cancellationTokenSource.Token).ConfigureAwait(false);
+
+                    lock (syncRoot)
+                    {
+                        if (cancelRequested)
+                        {
+                            return;
+                        }
+
+                        if (Environment.TickCount64 - lastProgressTick >= timeoutMilliseconds)
+                        {
+                            cancelRequested = true;
+                            return;
+                        }
+                    }
+                }
+            }
+            catch (OperationCanceledException)
+            {
+            }
+        }
     }
 }

--- a/src/Snap.Hutao/Snap.Hutao/Service/Metadata/MetadataService.cs
+++ b/src/Snap.Hutao/Snap.Hutao/Service/Metadata/MetadataService.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.Caching.Memory;
 using Snap.Hutao.Core.DependencyInjection.Annotation.HttpClient;
 using Snap.Hutao.Core.Diagnostics;
 using Snap.Hutao.Core.ExceptionService;
+using Snap.Hutao.Core.IO;
 using Snap.Hutao.Service.Git;
 using System.Collections.Immutable;
 using System.IO;
@@ -16,7 +17,8 @@ namespace Snap.Hutao.Service.Metadata;
 [HttpClient(HttpClientConfiguration.Default)]
 internal sealed partial class MetadataService : IMetadataService
 {
-    private readonly TaskCompletionSource initializeCompletionSource = new();
+    private static readonly TimeSpan InitializationHardTimeout = TimeSpan.FromSeconds(15);
+    private readonly TaskCompletionSource initializeCompletionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
     private readonly IGitRepositoryService gitRepositoryService;
     private readonly ILogger<MetadataService> logger;
@@ -38,15 +40,61 @@ internal sealed partial class MetadataService : IMetadataService
 
     public async ValueTask InitializeInternalAsync(CancellationToken token = default)
     {
-        if (isInitialized)
+        if (isInitialized || initializeCompletionSource.Task.IsCompleted)
         {
             return;
         }
 
         using (ValueStopwatch.MeasureExecution(logger))
         {
-            (isInitialized, _) = await gitRepositoryService.EnsureRepositoryAsync("Snap.Metadata").ConfigureAwait(false);
-            initializeCompletionSource.TrySetResult();
+            try
+            {
+                Task<ValueResult<bool, ValueDirectory>> ensureTask = gitRepositoryService.EnsureRepositoryAsync("Snap.Metadata").AsTask();
+                Task completedTask = await Task.WhenAny(ensureTask, Task.Delay(InitializationHardTimeout, token)).ConfigureAwait(false);
+
+                if (completedTask != ensureTask)
+                {
+                    if (token.IsCancellationRequested)
+                    {
+                        isInitialized = false;
+                        logger.LogWarning("[Metadata] Initialization canceled");
+                        return;
+                    }
+
+                    isInitialized = false;
+                    logger.LogError("[Metadata] Initialization timed out after {TimeoutSeconds}s", InitializationHardTimeout.TotalSeconds);
+                    _ = ObserveEnsureRepositoryTaskAsync(ensureTask);
+                    return;
+                }
+
+                (isInitialized, _) = await ensureTask.ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (token.IsCancellationRequested)
+            {
+                isInitialized = false;
+                logger.LogWarning("[Metadata] Initialization canceled");
+            }
+            catch (Exception ex)
+            {
+                isInitialized = false;
+                logger.LogError(ex, "[Metadata] Initialization failed");
+            }
+            finally
+            {
+                initializeCompletionSource.TrySetResult();
+            }
+        }
+    }
+
+    private async Task ObserveEnsureRepositoryTaskAsync(Task<ValueResult<bool, ValueDirectory>> ensureTask)
+    {
+        try
+        {
+            await ensureTask.ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "[Metadata] Timed out initialization task completed with an exception later");
         }
     }
 


### PR DESCRIPTION
## Summary

- add timeout and retry handling when fetching repository mirror lists
- probe Git mirrors before clone/fetch to skip unreachable endpoints earlier
- retry stalled Git transfers on the same mirror when progress was observed, and switch mirrors after repeated no-progress or stalled attempts
- add a hard timeout for metadata initialization so the app can fail instead of waiting indefinitely

## Validation

- `dotnet build C:\114514\program\Snap.Hutao-main\src\Snap.Hutao\Snap.Hutao\Snap.Hutao.csproj -c Debug -p:AppxPackage=false -p:WindowsPackageType=None --no-restore`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 添加了元数据镜像探测和重试的状态提示信息。
  * 增强了镜像列表获取的容错能力，支持多次尝试和超时控制。

* **Bug 修复**
  * 改进了仓库初始化的超时管理机制，防止长时间等待。
  * 优化了镜像故障时的自动切换和重试逻辑。
  * 增强了传输进度监控，及时检测传输无活动情况。

* **改进**
  * 调整了仓库初始化流程的并发控制，提升稳定性。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wangdage12/Snap.Hutao/pull/37?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->