### PR TITLE
[codex] Add automatic launch resolution selection

### DIFF
--- a/src/Snap.Hutao/Snap.Hutao/Core/Setting/SettingKeys.cs
+++ b/src/Snap.Hutao/Snap.Hutao/Core/Setting/SettingKeys.cs
@@ -108,6 +108,7 @@ internal static class SettingKeys
     public const string LaunchIsScreenHeightEnabled                      = "Snap::Hutao::Game::CommandLine::ScreenHeight::Enabled";
     public const string LaunchScreenWidth                                = "Snap::Hutao::Game::CommandLine::ScreenWidth";
     public const string LaunchIsScreenWidthEnabled                       = "Snap::Hutao::Game::CommandLine::ScreenWidth::Enabled";
+    public const string LaunchUseCurrentMonitorResolution                = "Snap::Hutao::Game::CommandLine::ScreenResolution::UseCurrentMonitor";
     public const string LaunchUsingStarwardPlayTimeStatistics            = "Snap::Hutao::Game::InterProcess::Starward::PlayTimeStatistics";
     public const string LaunchUsingBetterGenshinImpactAutomation         = "Snap::Hutao::Game::InterProcess::BetterGenshinImpact::Automation";
     public const string LaunchDisableShowDamageText                      = "Snap::Hutao::Game::Island::DamageText::Show";

--- a/src/Snap.Hutao/Snap.Hutao/Resource/Localization/SH.en.resx
+++ b/src/Snap.Hutao/Snap.Hutao/Resource/Localization/SH.en.resx
@@ -1017,6 +1017,9 @@
   <data name="ServiceGameLaunchPhaseWaitingProcessExit" xml:space="preserve">
     <value>Waiting for the game process to close…</value>
   </data>
+  <data name="ServiceGameLaunchMonitorWindowsPrimary" xml:space="preserve">
+    <value>Windows primary monitor</value>
+  </data>
   <data name="ServiceGameLaunchingEnsureGameResourceShouldNotConvert" xml:space="preserve">
     <value>The target server matches the current local game resources, no conversion needed</value>
   </data>
@@ -2950,6 +2953,12 @@ Space Available: {2}</value>
   </data>
   <data name="ViewPageLaunchGameMonitorsDescription" xml:space="preserve">
     <value>Run the software on the selected monitor</value>
+  </data>
+  <data name="ViewPageLaunchGameUseCurrentMonitorResolutionDescription" xml:space="preserve">
+    <value>Read the resolution when launching. Uses the primary monitor when monitor selection is disabled, otherwise uses the selected monitor.</value>
+  </data>
+  <data name="ViewPageLaunchGameUseCurrentMonitorResolutionHeader" xml:space="preserve">
+    <value>Read screen resolution automatically</value>
   </data>
   <data name="ViewPageLaunchGameOptionsHeader" xml:space="preserve">
     <value>Game Options</value>

--- a/src/Snap.Hutao/Snap.Hutao/Resource/Localization/SH.resx
+++ b/src/Snap.Hutao/Snap.Hutao/Resource/Localization/SH.resx
@@ -1035,6 +1035,9 @@
   <data name="ServiceGameLaunchPhaseWaitingProcessExit" xml:space="preserve">
     <value>等待游戏进程退出</value>
   </data>
+  <data name="ServiceGameLaunchMonitorWindowsPrimary" xml:space="preserve">
+    <value>Windows 主显示器</value>
+  </data>
   <data name="ServiceGameLaunchingEnsureGameResourceShouldNotConvert" xml:space="preserve">
     <value>目标服务器与当前游戏资源匹配，无需转换</value>
   </data>
@@ -3005,6 +3008,12 @@
   </data>
   <data name="ViewPageLaunchGameMonitorsDescription" xml:space="preserve">
     <value>在指定的显示器上运行</value>
+  </data>
+  <data name="ViewPageLaunchGameUseCurrentMonitorResolutionDescription" xml:space="preserve">
+    <value>启动时自动读取分辨率。未启用显示器指定时使用主显示器分辨率；启用后使用所选显示器分辨率。</value>
+  </data>
+  <data name="ViewPageLaunchGameUseCurrentMonitorResolutionHeader" xml:space="preserve">
+    <value>自动读取屏幕分辨率</value>
   </data>
   <data name="ViewPageLaunchGameOptionsHeader" xml:space="preserve">
     <value>游戏选项</value>

--- a/src/Snap.Hutao/Snap.Hutao/Resource/Localization/SH.zh-Hant.resx
+++ b/src/Snap.Hutao/Snap.Hutao/Resource/Localization/SH.zh-Hant.resx
@@ -1017,6 +1017,9 @@
   <data name="ServiceGameLaunchPhaseWaitingProcessExit" xml:space="preserve">
     <value>等待遊戲程序退出</value>
   </data>
+  <data name="ServiceGameLaunchMonitorWindowsPrimary" xml:space="preserve">
+    <value>Windows 主要顯示器</value>
+  </data>
   <data name="ServiceGameLaunchingEnsureGameResourceShouldNotConvert" xml:space="preserve">
     <value>目標伺服器與目前遊戲資源匹配，無需轉換</value>
   </data>
@@ -2923,6 +2926,12 @@
   </data>
   <data name="ViewPageLaunchGameMonitorsDescription" xml:space="preserve">
     <value>在指定的顯示器上執行</value>
+  </data>
+  <data name="ViewPageLaunchGameUseCurrentMonitorResolutionDescription" xml:space="preserve">
+    <value>啟動時自動讀取解析度。未啟用顯示器指定時使用主要顯示器解析度；啟用後使用所選顯示器解析度。</value>
+  </data>
+  <data name="ViewPageLaunchGameUseCurrentMonitorResolutionHeader" xml:space="preserve">
+    <value>自動讀取螢幕解析度</value>
   </data>
   <data name="ViewPageLaunchGameOptionsHeader" xml:space="preserve">
     <value>遊戲選項</value>

--- a/src/Snap.Hutao/Snap.Hutao/Service/Game/LaunchOptions.cs
+++ b/src/Snap.Hutao/Snap.Hutao/Service/Game/LaunchOptions.cs
@@ -20,6 +20,8 @@ namespace Snap.Hutao.Service.Game;
 [Service(ServiceLifetime.Singleton)]
 internal sealed partial class LaunchOptions : DbStoreOptions, IRestrictedGamePathAccess
 {
+    private const int WindowsPrimaryMonitorValue = 0;
+
     [GeneratedConstructor(CallBaseConstructor = true)]
     public partial LaunchOptions(IServiceProvider serviceProvider);
 
@@ -53,16 +55,34 @@ internal sealed partial class LaunchOptions : DbStoreOptions, IRestrictedGamePat
     public IObservableProperty<bool> IsExclusive { get => field ??= CreateProperty(SettingKeys.LaunchIsExclusive, false); }
 
     [field: MaybeNull]
-    public IObservableProperty<bool> IsScreenWidthEnabled { get => field ??= CreateProperty(SettingKeys.LaunchIsScreenWidthEnabled, true); }
+    public IObservableProperty<bool> IsScreenWidthEnabled { get => field ??= CreateProperty(SettingKeys.LaunchIsScreenWidthEnabled, true).WithValueChangedCallback(OnManualResolutionControlStateChanged, this); }
 
     [field: MaybeNull]
     public IObservableProperty<int> ScreenWidth { get => field ??= CreateProperty(SettingKeys.LaunchScreenWidth, DisplayArea.Primary.OuterBounds.Width); }
 
     [field: MaybeNull]
-    public IObservableProperty<bool> IsScreenHeightEnabled { get => field ??= CreateProperty(SettingKeys.LaunchIsScreenHeightEnabled, true); }
+    public IObservableProperty<bool> IsScreenHeightEnabled { get => field ??= CreateProperty(SettingKeys.LaunchIsScreenHeightEnabled, true).WithValueChangedCallback(OnManualResolutionControlStateChanged, this); }
 
     [field: MaybeNull]
     public IObservableProperty<int> ScreenHeight { get => field ??= CreateProperty(SettingKeys.LaunchScreenHeight, DisplayArea.Primary.OuterBounds.Height); }
+
+    [field: MaybeNull]
+    public IObservableProperty<bool> UseCurrentMonitorResolution { get => field ??= CreateProperty(SettingKeys.LaunchUseCurrentMonitorResolution, false).WithValueChangedCallback(OnManualResolutionControlStateChanged, this); }
+
+    [field: MaybeNull]
+    public IObservableProperty<bool> IsAspectRatioSelectionEnabled { get => field ??= Property.CreateObservable(!UseCurrentMonitorResolution.Value); }
+
+    [field: MaybeNull]
+    public IObservableProperty<bool> IsScreenWidthInputEnabled { get => field ??= Property.CreateObservable(!UseCurrentMonitorResolution.Value && IsScreenWidthEnabled.Value); }
+
+    [field: MaybeNull]
+    public IObservableProperty<bool> IsScreenWidthToggleEnabled { get => field ??= Property.CreateObservable(!UseCurrentMonitorResolution.Value); }
+
+    [field: MaybeNull]
+    public IObservableProperty<bool> IsScreenHeightInputEnabled { get => field ??= Property.CreateObservable(!UseCurrentMonitorResolution.Value && IsScreenHeightEnabled.Value); }
+
+    [field: MaybeNull]
+    public IObservableProperty<bool> IsScreenHeightToggleEnabled { get => field ??= Property.CreateObservable(!UseCurrentMonitorResolution.Value); }
 
     [field: MaybeNull]
     public IObservableProperty<bool> IsMonitorEnabled { get => field ??= CreateProperty(SettingKeys.LaunchIsMonitorEnabled, true); }
@@ -70,7 +90,7 @@ internal sealed partial class LaunchOptions : DbStoreOptions, IRestrictedGamePat
     public ImmutableArray<NameValue<int>> Monitors { get; } = InitializeMonitors();
 
     [field: MaybeNull]
-    public IObservableProperty<NameValue<int>?> Monitor { get => field ??= CreatePropertyForSelectedOneBasedIndex(SettingKeys.LaunchMonitor, Monitors); }
+    public IObservableProperty<NameValue<int>?> Monitor { get => field ??= CreateProperty(SettingKeys.LaunchMonitor, 1).AsNameValue(Monitors); }
 
     [field: MaybeNull]
     public IObservableProperty<bool> IsPlatformTypeEnabled { get => field ??= CreateProperty(SettingKeys.LaunchIsPlatformTypeEnabled, false); }
@@ -162,9 +182,84 @@ internal sealed partial class LaunchOptions : DbStoreOptions, IRestrictedGamePat
     [field: MaybeNull]
     public IObservableProperty<bool> UsingOverlay { get => field ??= CreateProperty(SettingKeys.LaunchUsingOverlay, false); }
 
+    public (int Width, int Height) GetLaunchScreenResolution()
+    {
+        if (!UseCurrentMonitorResolution.Value)
+        {
+            return (ScreenWidth.Value, ScreenHeight.Value);
+        }
+
+        DisplayArea displayArea = ResolveLaunchDisplayArea();
+        return (displayArea.OuterBounds.Width, displayArea.OuterBounds.Height);
+    }
+
+    public int GetLaunchMonitorValue()
+    {
+        if (Monitor.Value?.Value is not WindowsPrimaryMonitorValue)
+        {
+            return Monitor.Value?.Value ?? 1;
+        }
+
+        try
+        {
+            IReadOnlyList<DisplayArea> displayAreas = DisplayArea.FindAll();
+            ulong primaryDisplayId = DisplayArea.Primary.DisplayId.Value;
+            for (int i = 0; i < displayAreas.Count; i++)
+            {
+                if (displayAreas[i].DisplayId.Value == primaryDisplayId)
+                {
+                    return i + 1;
+                }
+            }
+        }
+        catch
+        {
+        }
+
+        return 1;
+    }
+
     private static int InitializeTargetFpsWithScreenFps()
     {
         return HutaoNative.Instance.MakeDeviceCapabilities().GetPrimaryScreenVerticalRefreshRate();
+    }
+
+    private static void OnManualResolutionControlStateChanged(bool _, LaunchOptions options)
+    {
+        options.RefreshManualResolutionControlStates();
+    }
+
+    private void RefreshManualResolutionControlStates()
+    {
+        bool canEditManualResolution = !UseCurrentMonitorResolution.Value;
+        IsAspectRatioSelectionEnabled.Value = canEditManualResolution;
+        IsScreenWidthInputEnabled.Value = canEditManualResolution && IsScreenWidthEnabled.Value;
+        IsScreenWidthToggleEnabled.Value = canEditManualResolution;
+        IsScreenHeightInputEnabled.Value = canEditManualResolution && IsScreenHeightEnabled.Value;
+        IsScreenHeightToggleEnabled.Value = canEditManualResolution;
+    }
+
+    private DisplayArea ResolveLaunchDisplayArea()
+    {
+        if (!IsMonitorEnabled.Value)
+        {
+            return DisplayArea.Primary;
+        }
+
+        try
+        {
+            IReadOnlyList<DisplayArea> displayAreas = DisplayArea.FindAll();
+            int selectedIndex = Math.Max(GetLaunchMonitorValue() - 1, 0);
+            if ((uint)selectedIndex < (uint)displayAreas.Count)
+            {
+                return displayAreas[selectedIndex];
+            }
+        }
+        catch
+        {
+        }
+
+        return DisplayArea.Primary;
     }
 
     private static void OnTargetFpsChanged(int newFps)
@@ -262,6 +357,8 @@ internal sealed partial class LaunchOptions : DbStoreOptions, IRestrictedGamePat
     private static ImmutableArray<NameValue<int>> InitializeMonitors()
     {
         ImmutableArray<NameValue<int>>.Builder monitors = ImmutableArray.CreateBuilder<NameValue<int>>();
+        monitors.Add(new(SH.ServiceGameLaunchMonitorWindowsPrimary, WindowsPrimaryMonitorValue));
+
         try
         {
             // This list can't use foreach

--- a/src/Snap.Hutao/Snap.Hutao/Service/Game/Launching/GameProcessFactory.cs
+++ b/src/Snap.Hutao/Snap.Hutao/Service/Game/Launching/GameProcessFactory.cs
@@ -14,6 +14,9 @@ internal sealed class GameProcessFactory
     public static IProcess CreateForDefault(BeforeLaunchExecutionContext context)
     {
         LaunchOptions launchOptions = context.LaunchOptions;
+        (int launchScreenWidth, int launchScreenHeight) = launchOptions.GetLaunchScreenResolution();
+        int launchMonitorValue = launchOptions.GetLaunchMonitorValue();
+        bool useCurrentMonitorResolution = launchOptions.UseCurrentMonitorResolution.Value;
 
         string commandLine = string.Empty;
         if (launchOptions.AreCommandLineArgumentsEnabled.Value)
@@ -29,16 +32,16 @@ internal sealed class GameProcessFactory
                 .AppendIf(launchOptions.IsBorderless.Value, "-popupwindow")
                 .AppendIf(launchOptions.IsExclusive.Value, "-window-mode", "exclusive")
                 .Append("-screen-fullscreen", launchOptions.IsFullScreen.Value ? "1" : "0")
-                .AppendIf(launchOptions.IsScreenWidthEnabled.Value, "-screen-width", launchOptions.ScreenWidth.Value)
-                .AppendIf(launchOptions.IsScreenHeightEnabled.Value, "-screen-height", launchOptions.ScreenHeight.Value)
-                .AppendIf(launchOptions.IsMonitorEnabled.Value, "-monitor", launchOptions.Monitor.Value?.Value ?? 1)
+                .AppendIf(useCurrentMonitorResolution || launchOptions.IsScreenWidthEnabled.Value, "-screen-width", launchScreenWidth)
+                .AppendIf(useCurrentMonitorResolution || launchOptions.IsScreenHeightEnabled.Value, "-screen-height", launchScreenHeight)
+                .AppendIf(launchOptions.IsMonitorEnabled.Value, "-monitor", launchMonitorValue)
                 .AppendIf(launchOptions.IsPlatformTypeEnabled.Value, "-platform_type", $"{launchOptions.PlatformType.Value:G}")
                 .AppendIf(useAuthTicket, "login_auth_ticket", authTicket, CommandLineArgumentPrefix.Equal)
                 .ToString();
 
             context.TaskContext.InvokeOnMainThread(() =>
             {
-                launchOptions.AspectRatios.Add(new(launchOptions.ScreenWidth.Value, launchOptions.ScreenHeight.Value));
+                launchOptions.AspectRatios.Add(new(launchScreenWidth, launchScreenHeight));
             });
         }
 

--- a/src/Snap.Hutao/Snap.Hutao/UI/Xaml/View/Page/LaunchGamePage.xaml
+++ b/src/Snap.Hutao/Snap.Hutao/UI/Xaml/View/Page/LaunchGamePage.xaml
@@ -479,6 +479,7 @@
                                                     <shuxc:SizeRestrictedContentControl Margin="0,0,130,0" VerticalAlignment="Center">
                                                         <ComboBox
                                                             MinWidth="{ThemeResource SettingsCardContentControlMinWidth2}"
+                                                            IsEnabled="{Binding LaunchOptions.IsAspectRatioSelectionEnabled.Value}"
                                                             ItemTemplateSelector="{StaticResource AspectRatioComboBoxTemplateSelector}"
                                                             ItemsSource="{Binding LaunchOptions.AspectRatios.Value}"
                                                             PlaceholderText="{shuxm:ResourceString Name=ViewPageLaunchGameAppearanceAspectRatioPlaceHolder}"
@@ -492,9 +493,12 @@
                                                             MinWidth="{ThemeResource SettingsCardContentControlMinWidth2}"
                                                             Padding="12,6,0,0"
                                                             VerticalAlignment="Center"
-                                                            IsEnabled="{Binding LaunchOptions.IsScreenWidthEnabled.Value}"
+                                                            IsEnabled="{Binding LaunchOptions.IsScreenWidthInputEnabled.Value}"
                                                             Value="{Binding LaunchOptions.ScreenWidth.Value, Mode=TwoWay}"/>
-                                                        <ToggleSwitch MinWidth="{ThemeResource SettingsCardContentControlMinWidth}" IsOn="{Binding LaunchOptions.IsScreenWidthEnabled.Value, Mode=TwoWay}"/>
+                                                        <ToggleSwitch
+                                                            MinWidth="{ThemeResource SettingsCardContentControlMinWidth}"
+                                                            IsEnabled="{Binding LaunchOptions.IsScreenWidthToggleEnabled.Value}"
+                                                            IsOn="{Binding LaunchOptions.IsScreenWidthEnabled.Value, Mode=TwoWay}"/>
                                                     </StackPanel>
                                                 </cwc:SettingsCard>
                                                 <cwc:SettingsCard Description="{shuxm:ResourceString Name=ViewPageLaunchGameAppearanceScreenHeightDescription}" Header="-screen-height">
@@ -503,9 +507,12 @@
                                                             MinWidth="{ThemeResource SettingsCardContentControlMinWidth2}"
                                                             Padding="12,6,0,0"
                                                             VerticalAlignment="Center"
-                                                            IsEnabled="{Binding LaunchOptions.IsScreenHeightEnabled.Value}"
+                                                            IsEnabled="{Binding LaunchOptions.IsScreenHeightInputEnabled.Value}"
                                                             Value="{Binding LaunchOptions.ScreenHeight.Value, Mode=TwoWay}"/>
-                                                        <ToggleSwitch MinWidth="{ThemeResource SettingsCardContentControlMinWidth}" IsOn="{Binding LaunchOptions.IsScreenHeightEnabled.Value, Mode=TwoWay}"/>
+                                                        <ToggleSwitch
+                                                            MinWidth="{ThemeResource SettingsCardContentControlMinWidth}"
+                                                            IsEnabled="{Binding LaunchOptions.IsScreenHeightToggleEnabled.Value}"
+                                                            IsOn="{Binding LaunchOptions.IsScreenHeightEnabled.Value, Mode=TwoWay}"/>
                                                     </StackPanel>
                                                 </cwc:SettingsCard>
                                                 <cwc:SettingsCard Description="{shuxm:ResourceString Name=ViewPageLaunchGameMonitorsDescription}" Header="-monitor">
@@ -524,6 +531,9 @@
                                                         </shuxc:SizeRestrictedContentControl>
                                                         <ToggleSwitch MinWidth="{ThemeResource SettingsCardContentControlMinWidth}" IsOn="{Binding LaunchOptions.IsMonitorEnabled.Value, Mode=TwoWay}"/>
                                                     </StackPanel>
+                                                </cwc:SettingsCard>
+                                                <cwc:SettingsCard Description="{shuxm:ResourceString Name=ViewPageLaunchGameUseCurrentMonitorResolutionDescription}" Header="{shuxm:ResourceString Name=ViewPageLaunchGameUseCurrentMonitorResolutionHeader}">
+                                                    <ToggleSwitch MinWidth="{ThemeResource SettingsCardContentControlMinWidth}" IsOn="{Binding LaunchOptions.UseCurrentMonitorResolution.Value, Mode=TwoWay}"/>
                                                 </cwc:SettingsCard>
                                             </cwc:SettingsExpander.Items>
                                         </cwc:SettingsExpander>


### PR DESCRIPTION
﻿## Summary

Adds an option to automatically read the launch resolution from the target display instead of requiring manually configured width and height.

## Details

- Add a launch setting for automatic monitor resolution detection.
- Add a Windows primary monitor option so the default Windows display can be used explicitly.
- Disable manual width, height, and aspect-ratio controls while automatic resolution mode is enabled.
- Use the resolved launch display size when building `-screen-width`, `-screen-height`, and aspect-ratio launch arguments.
- Add Simplified Chinese, Traditional Chinese, and English localization strings.

## Validation

- `git diff --check`
- `dotnet build C:\114514\program\Snap.Hutao-main\src\Snap.Hutao\Snap.Hutao\Snap.Hutao.csproj -c Debug -p:AppxPackage=false -p:WindowsPackageType=None --no-restore`
- Manual test build was provided before opening this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 新特性

* 游戏启动时新增"使用当前显示器分辨率"选项，支持自动应用当前监视器的分辨率
* 增强显示器选择功能，新增 Windows 主显示器作为自动选项
* 改进分辨率相关 UI 控件的启用状态管理逻辑

## 本地化

* 为新增功能添加了英文、繁体中文等多语言界面文案

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wangdage12/Snap.Hutao/pull/38?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->