### PR TITLE
Use target monitor resolution for launch

### DIFF
--- a/src/Snap.Hutao/Snap.Hutao/Core/Setting/SettingKeys.cs
+++ b/src/Snap.Hutao/Snap.Hutao/Core/Setting/SettingKeys.cs
@@ -108,6 +108,7 @@ internal static class SettingKeys
     public const string LaunchIsScreenHeightEnabled                      = "Snap::Hutao::Game::CommandLine::ScreenHeight::Enabled";
     public const string LaunchScreenWidth                                = "Snap::Hutao::Game::CommandLine::ScreenWidth";
     public const string LaunchIsScreenWidthEnabled                       = "Snap::Hutao::Game::CommandLine::ScreenWidth::Enabled";
+    public const string LaunchUseTargetMonitorResolution                 = "Snap::Hutao::Game::CommandLine::ScreenResolution::UseTargetMonitor";
     public const string LaunchUsingStarwardPlayTimeStatistics            = "Snap::Hutao::Game::InterProcess::Starward::PlayTimeStatistics";
     public const string LaunchUsingBetterGenshinImpactAutomation         = "Snap::Hutao::Game::InterProcess::BetterGenshinImpact::Automation";
     public const string LaunchDisableShowDamageText                      = "Snap::Hutao::Game::Island::DamageText::Show";

--- a/src/Snap.Hutao/Snap.Hutao/Resource/Localization/SH.resx
+++ b/src/Snap.Hutao/Snap.Hutao/Resource/Localization/SH.resx
@@ -1035,6 +1035,9 @@
   <data name="ServiceGameLaunchPhaseWaitingProcessExit" xml:space="preserve">
     <value>等待游戏进程退出</value>
   </data>
+  <data name="ServiceGameLaunchMonitorWindowsPrimary" xml:space="preserve">
+    <value>Windows 主显示器</value>
+  </data>
   <data name="ServiceGameLaunchingEnsureGameResourceShouldNotConvert" xml:space="preserve">
     <value>目标服务器与当前游戏资源匹配，无需转换</value>
   </data>
@@ -3005,6 +3008,12 @@
   </data>
   <data name="ViewPageLaunchGameMonitorsDescription" xml:space="preserve">
     <value>在指定的显示器上运行</value>
+  </data>
+  <data name="ViewPageLaunchGameUseTargetMonitorResolutionDescription" xml:space="preserve">
+    <value>启用后手动宽高将失效；未指定显示器时使用 Windows 主显示器。</value>
+  </data>
+  <data name="ViewPageLaunchGameUseTargetMonitorResolutionHeader" xml:space="preserve">
+    <value>使用目标显示器分辨率</value>
   </data>
   <data name="ViewPageLaunchGameOptionsHeader" xml:space="preserve">
     <value>游戏选项</value>

--- a/src/Snap.Hutao/Snap.Hutao/Service/Game/LaunchOptions.cs
+++ b/src/Snap.Hutao/Snap.Hutao/Service/Game/LaunchOptions.cs
@@ -20,6 +20,8 @@ namespace Snap.Hutao.Service.Game;
 [Service(ServiceLifetime.Singleton)]
 internal sealed partial class LaunchOptions : DbStoreOptions, IRestrictedGamePathAccess
 {
+    private const int WindowsPrimaryMonitorValue = 0;
+
     [GeneratedConstructor(CallBaseConstructor = true)]
     public partial LaunchOptions(IServiceProvider serviceProvider);
 
@@ -65,12 +67,15 @@ internal sealed partial class LaunchOptions : DbStoreOptions, IRestrictedGamePat
     public IObservableProperty<int> ScreenHeight { get => field ??= CreateProperty(SettingKeys.LaunchScreenHeight, DisplayArea.Primary.OuterBounds.Height); }
 
     [field: MaybeNull]
+    public IObservableProperty<bool> UseTargetMonitorResolution { get => field ??= CreateProperty(SettingKeys.LaunchUseTargetMonitorResolution, false); }
+
+    [field: MaybeNull]
     public IObservableProperty<bool> IsMonitorEnabled { get => field ??= CreateProperty(SettingKeys.LaunchIsMonitorEnabled, true); }
 
     public ImmutableArray<NameValue<int>> Monitors { get; } = InitializeMonitors();
 
     [field: MaybeNull]
-    public IObservableProperty<NameValue<int>?> Monitor { get => field ??= CreatePropertyForSelectedOneBasedIndex(SettingKeys.LaunchMonitor, Monitors); }
+    public IObservableProperty<NameValue<int>?> Monitor { get => field ??= CreateProperty(SettingKeys.LaunchMonitor, 1).AsNameValue(Monitors); }
 
     [field: MaybeNull]
     public IObservableProperty<bool> IsPlatformTypeEnabled { get => field ??= CreateProperty(SettingKeys.LaunchIsPlatformTypeEnabled, false); }
@@ -162,9 +167,69 @@ internal sealed partial class LaunchOptions : DbStoreOptions, IRestrictedGamePat
     [field: MaybeNull]
     public IObservableProperty<bool> UsingOverlay { get => field ??= CreateProperty(SettingKeys.LaunchUsingOverlay, false); }
 
+    public (int Width, int Height) GetLaunchScreenResolution()
+    {
+        if (!UseTargetMonitorResolution.Value)
+        {
+            return (ScreenWidth.Value, ScreenHeight.Value);
+        }
+
+        DisplayArea displayArea = ResolveLaunchDisplayArea();
+        return (displayArea.OuterBounds.Width, displayArea.OuterBounds.Height);
+    }
+
+    public int GetLaunchMonitorValue()
+    {
+        if (Monitor.Value?.Value is not WindowsPrimaryMonitorValue)
+        {
+            return Monitor.Value?.Value ?? 1;
+        }
+
+        try
+        {
+            IReadOnlyList<DisplayArea> displayAreas = DisplayArea.FindAll();
+            ulong primaryDisplayId = DisplayArea.Primary.DisplayId.Value;
+            for (int i = 0; i < displayAreas.Count; i++)
+            {
+                if (displayAreas[i].DisplayId.Value == primaryDisplayId)
+                {
+                    return i + 1;
+                }
+            }
+        }
+        catch
+        {
+        }
+
+        return 1;
+    }
+
     private static int InitializeTargetFpsWithScreenFps()
     {
         return HutaoNative.Instance.MakeDeviceCapabilities().GetPrimaryScreenVerticalRefreshRate();
+    }
+
+    private DisplayArea ResolveLaunchDisplayArea()
+    {
+        if (!IsMonitorEnabled.Value)
+        {
+            return DisplayArea.Primary;
+        }
+
+        try
+        {
+            IReadOnlyList<DisplayArea> displayAreas = DisplayArea.FindAll();
+            int selectedIndex = Math.Max(GetLaunchMonitorValue() - 1, 0);
+            if ((uint)selectedIndex < (uint)displayAreas.Count)
+            {
+                return displayAreas[selectedIndex];
+            }
+        }
+        catch
+        {
+        }
+
+        return DisplayArea.Primary;
     }
 
     private static void OnTargetFpsChanged(int newFps)
@@ -262,6 +327,8 @@ internal sealed partial class LaunchOptions : DbStoreOptions, IRestrictedGamePat
     private static ImmutableArray<NameValue<int>> InitializeMonitors()
     {
         ImmutableArray<NameValue<int>>.Builder monitors = ImmutableArray.CreateBuilder<NameValue<int>>();
+        monitors.Add(new(SH.ServiceGameLaunchMonitorWindowsPrimary, WindowsPrimaryMonitorValue));
+
         try
         {
             // This list can't use foreach
@@ -276,7 +343,6 @@ internal sealed partial class LaunchOptions : DbStoreOptions, IRestrictedGamePat
         }
         catch
         {
-            monitors.Clear();
         }
 
         return monitors.ToImmutable();

--- a/src/Snap.Hutao/Snap.Hutao/Service/Game/Launching/GameProcessFactory.cs
+++ b/src/Snap.Hutao/Snap.Hutao/Service/Game/Launching/GameProcessFactory.cs
@@ -14,6 +14,9 @@ internal sealed class GameProcessFactory
     public static IProcess CreateForDefault(BeforeLaunchExecutionContext context)
     {
         LaunchOptions launchOptions = context.LaunchOptions;
+        (int launchScreenWidth, int launchScreenHeight) = launchOptions.GetLaunchScreenResolution();
+        int launchMonitorValue = launchOptions.GetLaunchMonitorValue();
+        bool useTargetMonitorResolution = launchOptions.UseTargetMonitorResolution.Value;
 
         string commandLine = string.Empty;
         if (launchOptions.AreCommandLineArgumentsEnabled.Value)
@@ -29,16 +32,16 @@ internal sealed class GameProcessFactory
                 .AppendIf(launchOptions.IsBorderless.Value, "-popupwindow")
                 .AppendIf(launchOptions.IsExclusive.Value, "-window-mode", "exclusive")
                 .Append("-screen-fullscreen", launchOptions.IsFullScreen.Value ? "1" : "0")
-                .AppendIf(launchOptions.IsScreenWidthEnabled.Value, "-screen-width", launchOptions.ScreenWidth.Value)
-                .AppendIf(launchOptions.IsScreenHeightEnabled.Value, "-screen-height", launchOptions.ScreenHeight.Value)
-                .AppendIf(launchOptions.IsMonitorEnabled.Value, "-monitor", launchOptions.Monitor.Value?.Value ?? 1)
+                .AppendIf(useTargetMonitorResolution || launchOptions.IsScreenWidthEnabled.Value, "-screen-width", launchScreenWidth)
+                .AppendIf(useTargetMonitorResolution || launchOptions.IsScreenHeightEnabled.Value, "-screen-height", launchScreenHeight)
+                .AppendIf(launchOptions.IsMonitorEnabled.Value, "-monitor", launchMonitorValue)
                 .AppendIf(launchOptions.IsPlatformTypeEnabled.Value, "-platform_type", $"{launchOptions.PlatformType.Value:G}")
                 .AppendIf(useAuthTicket, "login_auth_ticket", authTicket, CommandLineArgumentPrefix.Equal)
                 .ToString();
 
             context.TaskContext.InvokeOnMainThread(() =>
             {
-                launchOptions.AspectRatios.Add(new(launchOptions.ScreenWidth.Value, launchOptions.ScreenHeight.Value));
+                launchOptions.AspectRatios.Add(new(launchScreenWidth, launchScreenHeight));
             });
         }
 

--- a/src/Snap.Hutao/Snap.Hutao/UI/Xaml/View/Page/LaunchGamePage.xaml
+++ b/src/Snap.Hutao/Snap.Hutao/UI/Xaml/View/Page/LaunchGamePage.xaml
@@ -525,6 +525,9 @@
                                                         <ToggleSwitch MinWidth="{ThemeResource SettingsCardContentControlMinWidth}" IsOn="{Binding LaunchOptions.IsMonitorEnabled.Value, Mode=TwoWay}"/>
                                                     </StackPanel>
                                                 </cwc:SettingsCard>
+                                                <cwc:SettingsCard Description="{shuxm:ResourceString Name=ViewPageLaunchGameUseTargetMonitorResolutionDescription}" Header="{shuxm:ResourceString Name=ViewPageLaunchGameUseTargetMonitorResolutionHeader}">
+                                                    <ToggleSwitch MinWidth="{ThemeResource SettingsCardContentControlMinWidth}" IsOn="{Binding LaunchOptions.UseTargetMonitorResolution.Value, Mode=TwoWay}"/>
+                                                </cwc:SettingsCard>
                                             </cwc:SettingsExpander.Items>
                                         </cwc:SettingsExpander>
                                     </ScrollViewer>


### PR DESCRIPTION
﻿## Summary

Adds a launch option to use the target monitor resolution as the game launch width and height.

## Details

- Adds a command-line option setting for target monitor resolution.
- Resolves Windows primary monitor to the matching Unity monitor index when needed.
- Uses the selected target display size for `-screen-width` and `-screen-height` when enabled.
- Keeps manual width and height settings unchanged, but ignores them while the target monitor resolution option is enabled.
- Adds only the Simplified Chinese resource strings in `SH.resx`.

## Validation

- `git diff --check`
- `dotnet build C:\114514\program\Snap.Hutao-main\src\Snap.Hutao\Snap.Hutao\Snap.Hutao.csproj -c Debug -p:AppxPackage=false -p:WindowsPackageType=None --no-restore`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 新增多显示器分辨率支持。启用目标显示器分辨率后，游戏将自动采用所选显示器的分辨率，而非手动设置的分辨率值
  * 在启动设置中新增显示器选择选项，支持选择 Windows 主显示器；未指定显示器时默认使用主屏幕
  * 新增启动设置 UI 切换开关，便于灵活启用或禁用目标显示器分辨率功能

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wangdage12/Snap.Hutao/pull/39?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->