### PR TITLE
Add metadata mirror timeout and probe

### DIFF
--- a/src/Snap.Hutao/Snap.Hutao/Resource/Localization/SH.resx
+++ b/src/Snap.Hutao/Snap.Hutao/Resource/Localization/SH.resx
@@ -1139,6 +1139,12 @@
   <data name="ServiceGitRepositoryOperationFailed" xml:space="preserve">
     <value>操作失败</value>
   </data>
+  <data name="ServiceGitRepositoryFetchingMirrorList" xml:space="preserve">
+    <value>获取元数据镜像列表</value>
+  </data>
+  <data name="ServiceGitRepositoryProbingMirror" xml:space="preserve">
+    <value>检查元数据镜像</value>
+  </data>
   <data name="ServiceGitRepositoryUpdatingExisting" xml:space="preserve">
     <value>检查元数据更新</value>
   </data>

--- a/src/Snap.Hutao/Snap.Hutao/Service/Git/GitRepositoryService.cs
+++ b/src/Snap.Hutao/Snap.Hutao/Service/Git/GitRepositoryService.cs
@@ -13,6 +13,8 @@ using Snap.Hutao.Web.Hutao.Response;
 using Snap.Hutao.Web.Response;
 using System.Collections.Immutable;
 using System.IO;
+using System.Net.Http;
+using System.Net.Http.Headers;
 
 namespace Snap.Hutao.Service.Git;
 
@@ -24,6 +26,10 @@ internal sealed partial class GitRepositoryService : IGitRepositoryService
     private readonly ILogger<GitRepositoryService> logger;
     private readonly IServiceProvider serviceProvider;
     private readonly ITaskContext taskContext;
+    private static readonly TimeSpan MirrorListRequestTimeout = TimeSpan.FromSeconds(6);
+    private static readonly TimeSpan MirrorProbeConnectTimeout = TimeSpan.FromSeconds(3);
+    private static readonly TimeSpan MirrorProbeRequestTimeout = TimeSpan.FromSeconds(6);
+    private const int MirrorListMaxAttempts = 3;
 
     [GeneratedConstructor]
     public partial GitRepositoryService(IServiceProvider serviceProvider);
@@ -47,28 +53,37 @@ internal sealed partial class GitRepositoryService : IGitRepositoryService
         using (await repoLock.LockAsync(name).ConfigureAwait(false))
         {
             ImmutableArray<GitRepository> infos;
-            using (IServiceScope scope = serviceProvider.CreateScope())
-            {
-                HutaoInfrastructureClient infrastructureClient = scope.ServiceProvider.GetRequiredService<HutaoInfrastructureClient>();
-                HutaoResponse<ImmutableArray<GitRepository>> response = await infrastructureClient.GetGitRepositoryAsync(name).ConfigureAwait(false);
-                if (!ResponseValidator.TryValidate(response, scope.ServiceProvider, out infos))
-                {
-                    return new(false, default);
-                }
-            }
-
             string directory = Path.GetFullPath(Path.Combine(HutaoRuntime.GetDataRepositoryDirectory(), name));
             BackgroundActivity.BackgroundActivity activity = GetActivityByName(name);
+
+            await activity.NotifyAsync(taskContext).ConfigureAwait(false);
+            await activity.UpdateAsync(taskContext, SH.ServiceGitRepositoryFetchingMirrorList, false, false, false, true).ConfigureAwait(false);
+
+            using (IServiceScope scope = serviceProvider.CreateScope())
+            {
+                ImmutableArray<GitRepository>? fetchedInfos = await TryGetRepositoryInfosAsync(scope.ServiceProvider, name).ConfigureAwait(false);
+                if (fetchedInfos is not { } validInfos)
+                {
+                    await activity.UpdateAsync(taskContext, SH.ServiceGitRepositoryOperationFailed, false, true, false, false).ConfigureAwait(false);
+                    return new(false, default);
+                }
+
+                infos = validInfos;
+            }
 
             bool failed = false;
             List<Exception> exceptions = [];
             try
             {
-                await activity.NotifyAsync(taskContext).ConfigureAwait(false);
                 await activity.UpdateAsync(taskContext, SH.ServiceBackgroundActivityDefaultDescription, false, false, false, false).ConfigureAwait(false);
 
                 foreach (GitRepository info in RepositoryAffinity.Sort(infos))
                 {
+                    if (!await ProbeRepositoryAsync(activity, info).ConfigureAwait(false))
+                    {
+                        continue;
+                    }
+
                     try
                     {
                         try
@@ -105,6 +120,99 @@ internal sealed partial class GitRepositoryService : IGitRepositoryService
             await activity.NotifyAsync(taskContext).ConfigureAwait(false);
             await activity.UpdateAsync(taskContext, SH.ServiceGitRepositoryOperationFailed, false, true, false, false).ConfigureAwait(false);
             throw new GitRepositoryException(SH.ServiceGitRepositoryOperationFailed, exceptions);
+        }
+    }
+
+    private async ValueTask<ImmutableArray<GitRepository>?> TryGetRepositoryInfosAsync(IServiceProvider scopedServiceProvider, string name)
+    {
+        HutaoInfrastructureClient infrastructureClient = scopedServiceProvider.GetRequiredService<HutaoInfrastructureClient>();
+
+        for (int attempt = 1; attempt <= MirrorListMaxAttempts; attempt++)
+        {
+            try
+            {
+                using CancellationTokenSource timeoutCts = new(MirrorListRequestTimeout);
+                HutaoResponse<ImmutableArray<GitRepository>> response = await infrastructureClient.GetGitRepositoryAsync(name, timeoutCts.Token).ConfigureAwait(false);
+
+                if (ResponseValidator.TryValidateWithoutUINotification(response, scopedServiceProvider, out ImmutableArray<GitRepository> infos))
+                {
+                    if (attempt > 1)
+                    {
+                        logger.LogInformation("[Metadata] Repository mirror list recovered: Name={Name}, Attempt={Attempt}", name, attempt);
+                    }
+
+                    return infos;
+                }
+
+                logger.LogWarning("[Metadata] Repository mirror list request returned invalid response: Name={Name}, Attempt={Attempt}/{MaxAttempts}, ReturnCode={ReturnCode}, Message={Message}",
+                    name,
+                    attempt,
+                    MirrorListMaxAttempts,
+                    response.ReturnCode,
+                    response.Message);
+            }
+            catch (OperationCanceledException ex)
+            {
+                logger.LogWarning(ex, "[Metadata] Repository mirror list request timed out: Name={Name}, Attempt={Attempt}/{MaxAttempts}, RequestTimeout={RequestTimeout}s",
+                    name,
+                    attempt,
+                    MirrorListMaxAttempts,
+                    MirrorListRequestTimeout.TotalSeconds);
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex, "[Metadata] Repository mirror list request failed: Name={Name}, Attempt={Attempt}/{MaxAttempts}",
+                    name,
+                    attempt,
+                    MirrorListMaxAttempts);
+            }
+        }
+
+        logger.LogError("[Metadata] Repository mirror list request exhausted retries: Name={Name}, Attempts={Attempts}", name, MirrorListMaxAttempts);
+        return default;
+    }
+
+    private async ValueTask<bool> ProbeRepositoryAsync(BackgroundActivity.BackgroundActivity activity, GitRepository info)
+    {
+        string probeUrl = $"{info.HttpsUrl.OriginalString.TrimEnd('/')}/info/refs?service=git-upload-pack";
+        logger.LogInformation("[Metadata] Probing repository mirror: Url={Url}", probeUrl);
+        activity.Update(taskContext, $"{SH.ServiceGitRepositoryProbingMirror}: {info.Name}", false, false, false, true);
+
+        try
+        {
+            using SocketsHttpHandler handler = new()
+            {
+                UseProxy = true,
+                Proxy = HttpProxyUsingSystemProxy.Instance,
+                ConnectTimeout = MirrorProbeConnectTimeout,
+            };
+
+            using HttpClient client = new(handler)
+            {
+                Timeout = MirrorProbeRequestTimeout,
+            };
+
+            using HttpRequestMessage request = new(HttpMethod.Get, probeUrl);
+            if (!string.IsNullOrEmpty(info.Token))
+            {
+                string credentials = Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes($"{info.Username}:{info.Token}"));
+                request.Headers.Authorization = new AuthenticationHeaderValue("Basic", credentials);
+            }
+
+            using HttpResponseMessage response = await client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead).ConfigureAwait(false);
+            if (!response.IsSuccessStatusCode)
+            {
+                logger.LogWarning("[Metadata] Repository mirror probe failed: Url={Url}, StatusCode={StatusCode}", probeUrl, (int)response.StatusCode);
+                return false;
+            }
+
+            logger.LogInformation("[Metadata] Repository mirror probe succeeded: Url={Url}", probeUrl);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "[Metadata] Repository mirror probe failed: Url={Url}", probeUrl);
+            return false;
         }
     }
 


### PR DESCRIPTION
﻿## Summary

This PR improves metadata repository initialization before handing work to LibGit2:

- Adds timeout/retry handling when requesting metadata repository mirror information.
- Adds a lightweight preflight probe for each mirror before running clone/fetch.
- Adds user-facing progress text for mirror list fetching and mirror probing.

## Motivation

When metadata initialization fails or stalls, the current UI often does not show which phase is stuck. Some failures can happen before Git transfer starts, such as mirror list requests not returning or selected mirrors being unreachable.

This change makes those pre-Git phases bounded and more observable.

## Known issue

During local testing, we also observed another failure mode: after LibGit2Sharp has already started `Fetch` / `AdvancedClone`, a network interruption may leave metadata initialization stuck indefinitely, for example while receiving objects.

This PR does not fully solve that case. The reason is that the transfer is already inside LibGit2Sharp/libgit2 at that point, and the current progress callbacks are not a reliable timeout boundary. If the underlying network operation stops producing callbacks, managed code may not get a chance to cancel or recover cleanly.

We considered adding a progress watchdog around the callbacks, but that would still be unreliable because it depends on LibGit2 continuing to call back into managed code.

Possible follow-up designs include:

- Run the Git transfer in an isolated worker process, so the main app can enforce a hard timeout and abandon/terminate the worker safely.
- Replace the metadata transfer path with a download mechanism that supports explicit timeout, retry, and resume semantics.
- Investigate whether libgit2 options can provide a reliable low-speed timeout or transport timeout for this scenario.

This PR focuses on the parts that can be made reliable in the current structure: mirror list retrieval and mirror reachability probing before the Git transfer begins.

## Validation

- `git diff --check`
- `dotnet build src/Snap.Hutao/Snap.Hutao/Snap.Hutao.csproj -c Debug -p:AppxPackage=false -p:WindowsPackageType=None --no-restore`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 新增仓库镜像可用性检测机制，自动探测镜像健康状态
  * 实现镜像列表获取的重试逻辑，提升同步稳定性

* **本地化**
  * 新增镜像列表获取及镜像检测相关的本地化文本资源

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wangdage12/Snap.Hutao/pull/40?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->